### PR TITLE
feat(m2): top-bar search field filtering the current view

### DIFF
--- a/client/src/__tests__/AppShell.test.tsx
+++ b/client/src/__tests__/AppShell.test.tsx
@@ -1,7 +1,24 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useOutletContext } from 'react-router-dom'
 import { afterEach, describe, expect, it } from 'vitest'
-import AppShell from '../components/AppShell'
+import AppShell, { type SearchContext } from '../components/AppShell'
+
+const QueryProbe = () => {
+  const { query } = useOutletContext<SearchContext>()
+  return <div data-testid="probe-query">{query}</div>
+}
+
+const renderShellAt = (initialEntries: string[]) =>
+  render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/new" element={<QueryProbe />} />
+          <Route path="/discounted" element={<QueryProbe />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
 
 describe('AppShell', () => {
   afterEach(() => {
@@ -20,5 +37,46 @@ describe('AppShell', () => {
     expect(screen.getByRole('link', { name: 'Upcoming' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Discounted' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Plus' })).toBeInTheDocument()
+  })
+
+  it('renders a search input with the agreed a11y attributes', () => {
+    render(
+      <MemoryRouter>
+        <AppShell />
+      </MemoryRouter>,
+    )
+
+    const input = screen.getByRole('searchbox', { name: 'Search' })
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveAttribute('placeholder', 'Search')
+    expect(input).toHaveAttribute('autocomplete', 'off')
+    expect(input).toHaveAttribute('autocorrect', 'off')
+    expect(input).toHaveAttribute('spellcheck', 'false')
+  })
+
+  it('passes the typed query to sibling routes via Outlet context', () => {
+    renderShellAt(['/new'])
+
+    const input = screen.getByRole('searchbox', { name: 'Search' })
+    fireEvent.change(input, { target: { value: 'silksong' } })
+
+    expect(screen.getByTestId('probe-query')).toHaveTextContent('silksong')
+  })
+
+  it('clears the query when the route changes', () => {
+    renderShellAt(['/new'])
+
+    const input = screen.getByRole<HTMLInputElement>('searchbox', {
+      name: 'Search',
+    })
+    fireEvent.change(input, { target: { value: 'silksong' } })
+    expect(input.value).toBe('silksong')
+
+    fireEvent.click(screen.getByRole('link', { name: 'Discounted' }))
+
+    expect(
+      screen.getByRole<HTMLInputElement>('searchbox', { name: 'Search' }).value,
+    ).toBe('')
+    expect(screen.getByTestId('probe-query')).toHaveTextContent('')
   })
 })

--- a/client/src/components/AppShell.css
+++ b/client/src/components/AppShell.css
@@ -23,6 +23,24 @@
   white-space: nowrap;
 }
 
+.app-shell--search {
+  justify-self: end;
+  min-width: 0;
+  width: 220px;
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 14px;
+  color: inherit;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.app-shell--search:focus {
+  outline: 2px solid var(--border-color);
+  outline-offset: 1px;
+}
+
 .app-shell--main {
   padding: 12px 16px 24px;
 }
@@ -31,5 +49,10 @@
   .app-shell--header {
     grid-template-columns: 1fr;
     gap: 8px;
+  }
+
+  .app-shell--search {
+    justify-self: stretch;
+    width: auto;
   }
 }

--- a/client/src/components/AppShell.tsx
+++ b/client/src/components/AppShell.tsx
@@ -1,17 +1,44 @@
-import { Outlet } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Outlet, useLocation } from 'react-router-dom'
 import Navigation from './Navigation'
 import './AppShell.css'
 
-const AppShell = () => (
-  <div className="app-shell">
-    <header className="app-shell--header">
-      <div className="app-shell--brand">PS Store</div>
-      <Navigation />
-    </header>
-    <main className="app-shell--main">
-      <Outlet />
-    </main>
-  </div>
-)
+export type SearchContext = { readonly query: string }
+
+const AppShell = () => {
+  const [query, setQuery] = useState('')
+  const location = useLocation()
+
+  useEffect(() => {
+    setQuery('')
+  }, [location.pathname])
+
+  const context: SearchContext = { query }
+
+  return (
+    <div className="app-shell">
+      <header className="app-shell--header">
+        <div className="app-shell--brand">PS Store</div>
+        <Navigation />
+        <input
+          type="search"
+          aria-label="Search"
+          placeholder="Search"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="app-shell--search"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.currentTarget.value)
+          }}
+        />
+      </header>
+      <main className="app-shell--main">
+        <Outlet context={context} />
+      </main>
+    </div>
+  )
+}
 
 export default AppShell

--- a/client/src/components/Games.tsx
+++ b/client/src/components/Games.tsx
@@ -1,5 +1,8 @@
 import type { Game as GameObject, PageResult } from '@psstore/shared'
+import { filterGamesByName } from '@psstore/shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import type { SearchContext } from './AppShell'
 import Error from './Error'
 import GameCard from './GameCard'
 import ScrollToTopOnMount from './ScrollToTopOnMount'
@@ -15,6 +18,7 @@ interface GamesProps {
 }
 
 const Games = ({ label, fetch, emptyMessage = 'No games found' }: GamesProps) => {
+  const { query } = useOutletContext<SearchContext>()
   const [games, setGames] = useState<GameObject[]>([])
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
@@ -77,6 +81,8 @@ const Games = ({ label, fetch, emptyMessage = 'No games found' }: GamesProps) =>
     }
   }, [nextOffset, loadingMore, loadPage])
 
+  const filtered = filterGamesByName(games, query)
+
   if (error) {
     return <Error message="Failed to load games" />
   }
@@ -85,7 +91,7 @@ const Games = ({ label, fetch, emptyMessage = 'No games found' }: GamesProps) =>
     return <Loading loading={loading} />
   }
 
-  if (games.length === 0) {
+  if (filtered.length === 0) {
     return <Error message={emptyMessage} />
   }
 
@@ -94,7 +100,7 @@ const Games = ({ label, fetch, emptyMessage = 'No games found' }: GamesProps) =>
       <ScrollToTopOnMount />
       <div className="games--content">
         <div className="games--grid" data-label={label}>
-          {games.map((game) => (
+          {filtered.map((game) => (
             <GameCard key={game.id} game={game} />
           ))}
         </div>

--- a/shared/src/__tests__/filters.test.ts
+++ b/shared/src/__tests__/filters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { Game } from '../types/game.js'
-import { sortByDateDesc } from '../utils/filters.js'
+import { filterGamesByName, sortByDateDesc } from '../utils/filters.js'
 
 const games: Game[] = [
   {
@@ -56,5 +56,42 @@ describe('filters', () => {
     ]
     const sorted = sortByDateDesc(withInvalid)
     expect(sorted.map((g) => g.id)).toEqual(['1', '2', '3', '4'])
+  })
+})
+
+describe('filterGamesByName', () => {
+  const first = games[0]
+  const second = games[1]
+  if (!first || !second) {
+    throw new Error('fixture missing games')
+  }
+  const named: Game[] = [
+    { ...first, id: '1', name: 'abc xyz' },
+    { ...second, id: '2', name: '1234567x' },
+    { ...first, id: '3', name: 'Hollow Knight: Silksong' },
+  ]
+
+  it('returns the full list for an empty query', () => {
+    expect(filterGamesByName(named, '').map((g) => g.id)).toEqual([
+      '1',
+      '2',
+      '3',
+    ])
+  })
+
+  it('matches case-insensitively', () => {
+    expect(filterGamesByName(named, 'ABC').map((g) => g.id)).toEqual(['1'])
+  })
+
+  it('matches a substring anywhere in the name', () => {
+    expect(filterGamesByName(named, 'x').map((g) => g.id)).toEqual(['1', '2'])
+  })
+
+  it('treats a whitespace-only query as empty', () => {
+    expect(filterGamesByName(named, '   ').map((g) => g.id)).toEqual([
+      '1',
+      '2',
+      '3',
+    ])
   })
 })

--- a/shared/src/utils/filters.ts
+++ b/shared/src/utils/filters.ts
@@ -21,3 +21,14 @@ export const sortByDateDesc = (games: Game[]): Game[] =>
 
     return 0
   })
+
+export const filterGamesByName = (
+  games: readonly Game[],
+  query: string,
+): Game[] => {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') {
+    return [...games]
+  }
+  return games.filter((g) => g.name.toLowerCase().includes(needle))
+}


### PR DESCRIPTION
## Why

Closes #34. `VISION.md → Product Shape` step 2 prescribes a single free-text search field next to the four fixed tabs that filters the currently visible list. Today the nav has only the four tabs — type-to-find on a 60-card grid is a clear scroll-to-find improvement (`VISION.md → Decision Filter` Q1).

## What

- `shared/src/utils/filters.ts`: pure helper `filterGamesByName(games, query)` — trim once, lowercase once, substring `includes` against `game.name`. Empty / whitespace-only query returns the full list (cloned). Lives next to `sortByDateDesc`; React-free; unit-tested without a DOM.
- `client/src/components/AppShell.tsx`: header gains a single `<input type="search" aria-label="Search" placeholder="Search" autoComplete="off" autoCorrect="off" spellCheck={false} />` owned by `useState('')` in AppShell. `<Outlet context={{ query }} />` propagates the read-only value to sibling routes (the framework-native shape — no provider, no global state). `useEffect(() => setQuery(''), [location.pathname])` clears the field on tab change while keeping focus on the input (the `key={pathname}` alternative would have stolen it).
- `client/src/components/AppShell.css`: minimal styling for `.app-shell--search` — fits the existing `auto 1fr auto` desktop grid as the right-hand column; stretches to full width at the mobile breakpoint. No icon glyph, no clear-X restyling (native `type="search"` clear control retained), no visible `<label>`.
- `client/src/components/Games.tsx`: reads `useOutletContext<SearchContext>()`, derives `filtered = filterGamesByName(games, query)` between the existing fetched-state slots and the render branches, renders `filtered.map(...)`. Empty branch uses `filtered.length === 0` so a non-matching query reuses the existing `<Error message={emptyMessage} />` ("No games found") — no query echo, no result count. State shape unchanged: `loading` / `loadingMore` / `error` / `nextOffset`, the fetch effect, and the IntersectionObserver sentinel are deliberately untouched (out of scope per #34).
- `client/src/__tests__/AppShell.test.tsx`: three new cases — search input a11y attributes (role / aria-label / placeholder / autocomplete-off / autocorrect-off / spellcheck-false), typed query reaches sibling routes via `useOutletContext`, navigating to a different tab clears both the DOM value and the context.
- `shared/src/__tests__/filters.test.ts`: four new cases — empty query → full list; case-insensitive match; substring match anywhere in the name; whitespace-only query → full list.

## VISION decision filter

- Q1 (fewer clicks / less noise on the official store): **YES** — type-to-find beats scroll-to-find on a 60-card grid; no carousels added.
- Q2 (no accounts / no per-user state): **YES** — `useState` only, cleared on tab change, nothing persisted to `localStorage`, no URL state, no recent-search list.
- Q3 (PS5 + Finland + EUR scope): **YES** — filter operates on already-scoped fetched data; no schema change, no server change.
- Q4 (utilitarian, no decorative chrome): **YES** — one native `<input type="search">`; no autocomplete dropdown, no suggestions, no result count, no icon glyph, no debounce spinner, no keyboard hint.

## States handled

The filter introduces two render states on top of the existing Games state machine: non-empty query with matches (filtered grid shown) and non-empty query with zero matches (existing `<Error message="No games found" />` empty branch renders — no query echo, no editorial framing). The pre-existing `loading` / `loadingMore` / `error` branches are unaffected and dominate while a fetch is in flight, exactly as before.

## AGENTS.md / STACK.md sections involved

- `AGENTS.md §3.1` — pure helper in `shared/`; framework-native `Outlet` context for state lift.
- `AGENTS.md §3.2` — smallest UI state primitive (`useState` lifted to the obvious owner, no new ViewModel / Service).
- `AGENTS.md §3.3` — no parallel booleans; the filter is a derived `const`, not a state slot.
- `AGENTS.md §5` — substring on ≤ 60 fetched items is well inside the frame budget; no `useMemo` (premature per §7).
- `AGENTS.md §10` — named exports, immutable bindings, no `any`, no `as`-cast outside tests, no `print` / `console.log`.
- `AGENTS.md §15` — definition of done: `aria-label`, focus retention on clear-on-tab-change.
- `STACK.md §5` — no new persistence (`localStorage` untouched).
- `STACK.md §7` — no `useEffect` with empty deps for fetching; the new `useEffect` drives a state clear, not a fetch.

## Verification

`pnpm test-all` was run. Two pre-existing failures remain — `server/src/__tests__/app.test.ts` and its `dist/` mirror — both fail with `EPERM: operation not permitted listen 0.0.0.0`. Verified identical failures on `main` (commit `b45de8e`) — these are the sandbox-bind issues tracked separately (out of scope for M2). All other tests pass: shared (10/10), client (17/17 — up from 14), sony-contract-bot, server's non-listening suites.

## Autonomy fallback (AGENTS.md §14.1)

One ambiguity surfaced: the repo has no `.prettierrc` and the existing files use single-quote + no-semicolon style that `prettier` (defaults: double-quote + semicolon) would rewrite. Running `pnpm format` repo-wide would churn unrelated files. Conservative interpretation: kept my new code in the existing single-quote / no-semicolon house style (matching every other file in `shared/` and `client/`) and did NOT run `pnpm format` repo-wide. `pnpm lint` and `pnpm typecheck` are both clean. No binding constraint introduced — this is a pre-existing tooling discrepancy that pre-dates M2.

Co-Authored-By: lead-dev <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
