### PR TITLE
fix(server): PDP enrichment via Sony descriptions[]/genres[] + store-parity spike

### DIFF
--- a/docs/contracts/reports/graphql-store-parity-spike.md
+++ b/docs/contracts/reports/graphql-store-parity-spike.md
@@ -147,8 +147,9 @@ fixture `docs/contracts/samples/pragmata-pdp-descriptions-genres.json`):
   `combinedLocalizedGenres[]` (the non-existent `genres` / `description` /
   `longDescription` fields are removed).
 - `server/src/sony/productDetailSchema.ts` (new): a tolerant zod boundary schema
-  for the `productRetrieve` node — all fields optional, `.passthrough()` — so a
-  Sony shape change degrades to empty values instead of throwing
+  for the `productRetrieve` node — all fields optional, `z.looseObject` (the
+  non-deprecated Zod 4 replacement for `.passthrough()`) — so a Sony shape
+  change degrades to empty values instead of throwing
   (`STACK.md §7`, `AGENTS.md §6.1`). `extractProductDetail` parses through it and
   degrades to empty description / genres on parse failure.
 - `server/src/sony/sonyClient.ts → extractProductDetail`: rewritten to read the

--- a/docs/contracts/reports/graphql-store-parity-spike.md
+++ b/docs/contracts/reports/graphql-store-parity-spike.md
@@ -1,0 +1,168 @@
+# Research spike: Sony GraphQL capability map, store-parity, and PDP enrichment
+
+Status: read-only spike (architect) + implementation (lead-dev). This document
+is the durable audit trail for the PDP-enrichment fix and the listing-divergence
+investigation shipped in branch `feat/pdp-enrichment-graphql-spike`.
+
+Scope: the app's own anonymous, unauthenticated proxy of Sony's public fi-FI
+GraphQL (region `fi`, locale `fi-fi`, EUR, PS5).
+
+> Privacy note (per `VISION.md → Persistence and Privacy Posture` and
+> `AGENTS.md §8`): this document records only operation names, public
+> persisted-query sha256 hashes (already present in `server/src/config/env.ts`),
+> variable shapes, response field names / paths, category and concept ids, and
+> prose. It contains no request headers, cookies, tokens, IP addresses, or any
+> PII. The persisted-query hashes are public client constants, not secrets.
+
+---
+
+## A. GraphQL capability map
+
+All operations are issued as anonymous persisted queries against
+`https://web.np.playstation.com/api/graphql/v1/op` (GET), with the
+`x-apollo-operation-name` header set to the operation name and a
+locale-override header derived from `SONY_LOCALE`.
+
+### A.1 `categoryGridRetrieve` (the listing operation — in use)
+
+- Persisted-query hash: `257713466fc3264850aa473409a29088e3a4115e6e69e9fb3e061c8dd5b9f5c6`
+- Variables: `{ id, locale, pageArgs { size, offset }, sortBy { name, isAscending }, filterBy[], facetOptions[] }`
+  - The app requests `sortBy: { name: "conceptReleaseDate", isAscending: false }` and `filterBy: ["targetPlatforms:PS5"]` (plus per-feature filters, see `queryStrategies.ts`).
+- Root path: `data.categoryGridRetrieve`
+- Returns:
+  - `concepts[]` — `{ id, name, media[], price { basePrice, discountedPrice, discountText, serviceBranding, upsellServiceBranding, upsellText } }`
+  - `products[]`
+  - `pageInfo { totalCount, offset, size, isLast }`, `sortedBy`, `sortingOptions[]`, `facetOptions[]`
+- **Critical limitation:** each `concept.products[]` entry contains ONLY `{ __typename, id }`. There is no `releaseDate`, `genres`, or `providerName` on the grid response. The app's `mapper.ts` reads `concept.products[0].releaseDate / genres / providerName`, which are therefore always `undefined` — list cards have no per-product date or genres until enrichment runs.
+
+### A.2 `metGetProductById` (the PDP enrichment operation — in use)
+
+- Persisted-query hash: `a128042177bd93dd831164103d53b73ef790d56f51dae647064cb8f9d9fc9d1a`
+- Variables: `{ productId }`
+- Root path: `data.productRetrieve`
+- Returns (fields relevant to this product): `releaseDate` (ISO), `publisherName`, `descriptions[]`, `combinedLocalizedGenres[]`, `localizedStoreDisplayClassification`, `storeDisplayClassification`, `platforms[]`, `media[]`, `concept { __ref }`, `contentRating`, `edition`, `topCategory`.
+- This is the operation that carries the "game info" description and genres anonymously. No new operation or auth is needed for the PDP fix.
+
+### A.3 `conceptRetrieveForCtasWithPrice` (not used)
+
+- Returns `conceptRetrieve { id, defaultProduct { webctas { price { … } } }, products[], releaseDate { type, value }, isInWishlist }`. No descriptions / genres. Not called by this app.
+
+### A.4 Out of scope (never called)
+
+- The PDP "game info" panel on `store.playstation.com` is server-rendered from a `conceptRetrieve` whose hash is server-internal and not anonymously callable. We do NOT design around it; `metGetProductById` already carries the same description + genres.
+- Authenticated identity operations (e.g. `oracleUserProfile…`) exist but are out of scope and never called — the product has no accounts (`VISION.md → Non-Goals`).
+
+### A.5 Field usage matrix
+
+| Field path                                                  | Source op              | App uses it?  | Where                              |
+| ----------------------------------------------------------- | ---------------------- | ------------- | ---------------------------------- |
+| `categoryGridRetrieve.concepts[].id / name / media / price` | `categoryGridRetrieve` | Yes           | `mapper.ts → conceptToGame`        |
+| `categoryGridRetrieve.concepts[].products[].id`             | `categoryGridRetrieve` | Yes           | product id for enrichment / detail |
+| `categoryGridRetrieve.concepts[].products[].releaseDate`    | `categoryGridRetrieve` | No (absent)   | always undefined on grid; ignored  |
+| `categoryGridRetrieve.concepts[].products[].genres`         | `categoryGridRetrieve` | No (absent)   | always undefined on grid; ignored  |
+| `productRetrieve.releaseDate`                               | `metGetProductById`    | Yes           | listing date enrichment + PDP      |
+| `productRetrieve.publisherName`                             | `metGetProductById`    | Yes           | PDP `studio`                       |
+| `productRetrieve.descriptions[]` (LONG / SHORT)             | `metGetProductById`    | Yes (FIXED)   | PDP `description`                  |
+| `productRetrieve.combinedLocalizedGenres[]`                 | `metGetProductById`    | Yes (FIXED)   | PDP `genres`                       |
+| `productRetrieve.descriptions[]` (COMPATIBILITY/LEGAL)      | `metGetProductById`    | No (excluded) | never user-facing copy             |
+
+---
+
+## B. Listing divergence — root cause and VISION-aligned conclusion
+
+**Report.** The app's category id `d0446d4b-…` and the official "All games"
+category id `28c9c2b2-cecc-415c-9a08-482a605cb104`, queried with the same hash,
+sort, and filter, return identical head ordering; the official browse page
+renders that same order. So the server order the app receives IS the official
+browse order.
+
+The divergence is introduced entirely by client-side post-processing in
+`gamesService.ts`:
+
+1. Grid concepts carry `products[0] = { __typename, id }` only, so the mapper
+   sets `date = ''` for every list item.
+2. `getNewGames` runs `enrichGamesWithDates` — one `metGetProductById` call per
+   item — to backfill per-product `releaseDate`.
+3. The result is re-sorted purely by that per-product `releaseDate` and filtered
+   to released items (`date <= now`).
+
+The official `conceptReleaseDate`-desc head is dominated by FUTURE / placeholder
+dates (e.g. `2027-01-20`; long runs of YEAR-precision `2026-12-31` placeholders),
+which is why the official browse head looks alphabetical. `VISION.md → Product
+Shape #1` requires NEW to be "released today at top, then yesterday, descending
+by release date" — released-only, true newest-first.
+
+**Conclusion.** The app and the official browse answer different questions.
+Chasing byte-for-byte parity with the official browse head would surface undated
+FUTURE placeholders at the top of NEW and would VIOLATE the VISION default view.
+We do NOT chase official-browse parity.
+
+**`AGENTS.md §14.1` interpretation (smallest-surface, most-conservative,
+VISION-aligned):**
+
+- Keep the `released` filter and `date-desc` sort for NEW. This is correct per
+  VISION.
+- Make ONE genuine correctness improvement: the re-sort now uses the upstream
+  `conceptReleaseDate`-desc grid order as a STABLE tiebreaker, and unparseable /
+  missing dates sort to a fixed sentinel rather than producing `NaN`
+  comparisons. Before this change, equal or unparseable dates reordered
+  nondeterministically across requests (implementation-defined `Array.sort`
+  behaviour on `NaN` / `0` comparators). After it, ties deterministically keep
+  the official grid order Sony already returns.
+- We do NOT switch `SONY_CATEGORY_ID` (the optional `28c9c2b2-…` swap, 7578 vs
+  7208 concepts, is not adopted — no VISION benefit and it would not change the
+  released-newest-first answer).
+- We do NOT refactor the N+1 enrichment (a separate optimization, out of scope).
+- All existing SKU filtering (non-game / non-PS5 / DLC / editions / currency /
+  themes / PS4) is preserved unchanged — "align with official" never means
+  "stop filtering" (ux-guardian guardrail).
+
+---
+
+## C. PDP enrichment — the real bug
+
+**Root cause.** `server/src/sony/sonyClient.ts → extractProductDetail` read
+response fields that do not exist on `data.productRetrieve`
+(`product.genres`, `product.longDescription`, `product.description`), so the PDP
+description was always `''` and genres always `[]`.
+
+**Real response shape** (confirmed from the live capture; see the sanitized
+fixture `docs/contracts/samples/pragmata-pdp-descriptions-genres.json`):
+
+- Long description: `productRetrieve.descriptions[]` is an array of
+  `{ type, subType, value }` where `type ∈ "SHORT" | "LONG" |
+"COMPATIBILITY_NOTICE" | "LEGAL"`. Use the `LONG` entry's `.value`; fall back
+  to the `SHORT` entry's `.value`; never use `COMPATIBILITY_NOTICE` or `LEGAL`.
+  (Live: ~922 chars for concept `10016790`, ~1571 for PRAGMATA.) The LONG value
+  contains HTML (`<br>`, links) and is sanitized via DOMPurify in
+  `client/src/components/GameDetailsPage.tsx` — that sanitization is kept.
+- Genres: `productRetrieve.combinedLocalizedGenres[]` is an array of `{ value }`
+  (typename `LocalizedGenreSubGenre`). Map to `.value`, drop empties. (Live
+  fi-FI: `["Toiminta", "Roolipelit", "Kolmannen persoonan ammuntapeli"]`.)
+- `releaseDate` and `publisherName` already worked and are unchanged.
+
+**Fix shipped.**
+
+- `server/src/sony/types.ts`: `ProductDetail` now models `descriptions[]` and
+  `combinedLocalizedGenres[]` (the non-existent `genres` / `description` /
+  `longDescription` fields are removed).
+- `server/src/sony/productDetailSchema.ts` (new): a tolerant zod boundary schema
+  for the `productRetrieve` node — all fields optional, `.passthrough()` — so a
+  Sony shape change degrades to empty values instead of throwing
+  (`STACK.md §7`, `AGENTS.md §6.1`). `extractProductDetail` parses through it and
+  degrades to empty description / genres on parse failure.
+- `server/src/sony/sonyClient.ts → extractProductDetail`: rewritten to read the
+  real field paths while returning the unchanged `ProductDetailResult` shape, so
+  `gamesService` wiring is untouched.
+- `client/src/components/GameDetailsPage.tsx`: confirmed to already render
+  `game.description` (DOMPurify-sanitized) and `game.genres` conditionally — no
+  client change required.
+- The shared `Game` schema already has `description: string` and
+  `genres: string[]` — no schema change required.
+
+**Manifest contract note.** `metGetProductById` (`data.productRetrieve`) is
+intentionally NOT added to `docs/contracts/sony-graphql-manifest.json`. The
+contract-bot validator (`tools/sony-contract-bot/src/compat/backend.ts`) asserts
+every manifest operation's `response_path` is one of
+`data.categoryGridRetrieve.products` / `.concepts`; the PDP operation lives
+outside that grid-only contract by design and is documented here instead.

--- a/docs/contracts/samples/pragmata-pdp-descriptions-genres.json
+++ b/docs/contracts/samples/pragmata-pdp-descriptions-genres.json
@@ -1,0 +1,47 @@
+{
+  "note": "Synthetic, sanitized fixture for the metGetProductById -> data.productRetrieve node. Field names and value shapes mirror the live fi-FI anonymous response (spike doc section C). Contains only public field names, ids, and prose: no request headers, cookies, tokens, or PII. Description prose is illustrative, not the real Sony copy.",
+  "data": {
+    "productRetrieve": {
+      "__typename": "Product",
+      "id": "UP0102-PPSA02530_00-PRAGMATA00000000",
+      "releaseDate": "2026-04-23T21:00:00Z",
+      "publisherName": "CAPCOM",
+      "localizedStoreDisplayClassification": "Täysi peli",
+      "storeDisplayClassification": "FULL_GAME",
+      "descriptions": [
+        {
+          "__typename": "Description",
+          "type": "SHORT",
+          "subType": null,
+          "value": "A near-future action adventure on the Moon."
+        },
+        {
+          "__typename": "Description",
+          "type": "LONG",
+          "subType": null,
+          "value": "<p>Stranded on a lunar research station, you and an android companion must outwit a rogue intelligence.</p><br><p>Solve real-time hacking puzzles woven into third-person combat as the two of you fight to return home.</p>"
+        },
+        {
+          "__typename": "Description",
+          "type": "COMPATIBILITY_NOTICE",
+          "subType": "PS5",
+          "value": "This game is playable on PS5 consoles only."
+        },
+        {
+          "__typename": "Description",
+          "type": "LEGAL",
+          "subType": null,
+          "value": "© CAPCOM CO., LTD. All rights reserved."
+        }
+      ],
+      "combinedLocalizedGenres": [
+        { "__typename": "LocalizedGenreSubGenre", "value": "Toiminta" },
+        { "__typename": "LocalizedGenreSubGenre", "value": "Roolipelit" },
+        {
+          "__typename": "LocalizedGenreSubGenre",
+          "value": "Kolmannen persoonan ammuntapeli"
+        }
+      ]
+    }
+  }
+}

--- a/server/src/__tests__/gamesService.test.ts
+++ b/server/src/__tests__/gamesService.test.ts
@@ -311,4 +311,91 @@ describe('gamesService', () => {
 
     expect(page.nextOffset).toBeNull()
   })
+
+  it('orders games with equal release dates by upstream concept order (stable)', async () => {
+    // All three concepts share one parsed timestamp, so ordering must fall back
+    // to the upstream `conceptReleaseDate`-desc grid order rather than reorder
+    // nondeterministically (spike doc, section B).
+    const concepts = [makeConcept('first'), makeConcept('second'), makeConcept('third')]
+
+    fetchProductDetail.mockImplementation(async () => ({
+      releaseDate: '2025-01-01T00:00:00Z',
+      genres: [],
+      description: '',
+    }))
+
+    fetchConceptsByFeature.mockImplementation(async (feature: string) =>
+      feature === 'new' ? concepts : [],
+    )
+
+    const svc = await import('../services/gamesService.js')
+    const { games } = await svc.getNewGames()
+
+    expect(games.map((g) => g.name)).toEqual(['first', 'second', 'third'])
+  })
+})
+
+describe('getGameById detail enrichment (function-injection seam)', () => {
+  it('enriches the game with LONG description and localized genres', async () => {
+    fetchProductDetail.mockImplementation(async () => ({
+      releaseDate: PAST_DATE,
+      genres: [],
+      description: '',
+    }))
+    fetchConceptsByFeature.mockImplementation(async (feature: string) =>
+      feature === 'new' ? [makeConcept('detailed')] : [],
+    )
+
+    const svc = await import('../services/gamesService.js')
+    const baseGame = (await svc.getNewGames()).games[0]
+    if (!baseGame) {
+      throw new Error('test expected at least one new game')
+    }
+
+    const fakeFetchDetail = async (): Promise<{
+      releaseDate: string
+      genres: string[]
+      description: string
+      publisherName: string
+    }> => ({
+      releaseDate: PAST_DATE,
+      genres: ['Toiminta', 'Roolipelit'],
+      description: '<p>The long game info body.</p>',
+      publisherName: 'STUDIO OY',
+    })
+
+    const game = await svc.getGameById(baseGame.id, fakeFetchDetail)
+
+    expect(game.description).toBe('<p>The long game info body.</p>')
+    expect(game.genres).toEqual(['Toiminta', 'Roolipelit'])
+    expect(game.studio).toBe('STUDIO OY')
+  })
+
+  it('degrades to the un-enriched game when the detail fetch rejects', async () => {
+    fetchProductDetail.mockImplementation(async () => ({
+      releaseDate: PAST_DATE,
+      genres: [],
+      description: '',
+    }))
+    fetchConceptsByFeature.mockImplementation(async (feature: string) =>
+      feature === 'new' ? [makeConcept('degraded')] : [],
+    )
+
+    const svc = await import('../services/gamesService.js')
+    const baseGame = (await svc.getNewGames()).games[0]
+    if (!baseGame) {
+      throw new Error('test expected at least one new game')
+    }
+
+    const rejectingFetchDetail = async (): Promise<never> => {
+      throw new Error('upstream unavailable')
+    }
+
+    const game = await svc.getGameById(baseGame.id, rejectingFetchDetail)
+
+    expect(game.id).toBe(baseGame.id)
+    expect(game.name).toBe('degraded')
+    expect(game.description).toBe('')
+    expect(game.genres).toEqual([])
+  })
 })

--- a/server/src/__tests__/sonyClient.test.ts
+++ b/server/src/__tests__/sonyClient.test.ts
@@ -17,24 +17,71 @@ describe('extractReleaseDateFromProductResponse', () => {
 })
 
 describe('extractProductDetail', () => {
-  it('extracts releaseDate, genres, and description', () => {
+  it('uses the LONG description and maps combinedLocalizedGenres', () => {
     const result = extractProductDetail({
       data: {
         productRetrieve: {
           id: 'UP0102-PPSA02530_00-PRAGMATA00000000',
           releaseDate: '2026-04-23T21:00:00Z',
-          genres: ['Action', 'Adventure'],
-          longDescription: '<p>An amazing game</p>',
+          descriptions: [
+            { type: 'SHORT', value: 'A tagline.' },
+            { type: 'LONG', value: '<p>The long game info body.</p>' },
+            { type: 'COMPATIBILITY_NOTICE', value: 'Requires a PS5 console.' },
+            { type: 'LEGAL', value: '© Publisher. All rights reserved.' },
+          ],
+          combinedLocalizedGenres: [{ value: 'Toiminta' }, { value: 'Roolipelit' }],
         },
       },
     })
 
     expect(result.releaseDate).toBe('2026-04-23T21:00:00Z')
-    expect(result.genres).toEqual(['Action', 'Adventure'])
-    expect(result.description).toBe('<p>An amazing game</p>')
+    expect(result.description).toBe('<p>The long game info body.</p>')
+    expect(result.genres).toEqual(['Toiminta', 'Roolipelit'])
   })
 
-  it('returns empty defaults when fields are missing', () => {
+  it('excludes COMPATIBILITY_NOTICE and LEGAL when no LONG/SHORT exists', () => {
+    const result = extractProductDetail({
+      data: {
+        productRetrieve: {
+          id: 'test',
+          descriptions: [
+            { type: 'COMPATIBILITY_NOTICE', value: 'Requires a PS5 console.' },
+            { type: 'LEGAL', value: '© Publisher.' },
+          ],
+        },
+      },
+    })
+
+    expect(result.description).toBe('')
+  })
+
+  it('falls back to the SHORT description when LONG is missing', () => {
+    const result = extractProductDetail({
+      data: {
+        productRetrieve: {
+          id: 'test',
+          descriptions: [{ type: 'SHORT', value: 'Short tagline only.' }],
+        },
+      },
+    })
+
+    expect(result.description).toBe('Short tagline only.')
+  })
+
+  it('drops empty genre values', () => {
+    const result = extractProductDetail({
+      data: {
+        productRetrieve: {
+          id: 'test',
+          combinedLocalizedGenres: [{ value: 'Toiminta' }, { value: '' }, {}],
+        },
+      },
+    })
+
+    expect(result.genres).toEqual(['Toiminta'])
+  })
+
+  it('returns empty defaults when descriptions and genres are missing', () => {
     const result = extractProductDetail({
       data: { productRetrieve: { id: 'test' } },
     })
@@ -50,8 +97,6 @@ describe('extractProductDetail', () => {
         productRetrieve: {
           id: 'UP4139-PPSA27597_00-STELLARDELUXEPS5',
           releaseDate: '2025-11-11T00:00:00Z',
-          genres: ['Strategy'],
-          longDescription: '<p>Grand strategy</p>',
           publisherName: 'PARADOX GAMES INC',
         },
       },
@@ -68,17 +113,29 @@ describe('extractProductDetail', () => {
     expect(result.publisherName).toBeUndefined()
   })
 
-  it('falls back to description when longDescription is missing', () => {
-    const result = extractProductDetail({
+  it('degrades to empty values when the productRetrieve node is missing', () => {
+    const result = extractProductDetail({ data: {} })
+
+    expect(result.releaseDate).toBeUndefined()
+    expect(result.genres).toEqual([])
+    expect(result.description).toBe('')
+  })
+
+  it('tolerates a malformed payload without throwing', () => {
+    const malformed = {
       data: {
         productRetrieve: {
-          id: 'test',
-          description: 'Short desc',
+          id: 42,
+          descriptions: 'not-an-array',
+          combinedLocalizedGenres: { value: 'wrong-shape' },
         },
       },
-    })
+    } as unknown as Parameters<typeof extractProductDetail>[0]
 
-    expect(result.description).toBe('Short desc')
+    const result = extractProductDetail(malformed)
+
+    expect(result.releaseDate).toBeUndefined()
+    expect(result.genres).toEqual([])
+    expect(result.description).toBe('')
   })
 })
-

--- a/server/src/services/gamesService.ts
+++ b/server/src/services/gamesService.ts
@@ -32,12 +32,36 @@ const withCache = async <T>(key: string, resolve: () => Promise<T>): Promise<T> 
 
 type SortOrder = 'date-desc' | 'date-asc'
 
-const sortByDate = (games: Game[], order: SortOrder): Game[] =>
-  [...games].sort((a, b) => {
-    const aTs = Date.parse(a.date)
-    const bTs = Date.parse(b.date)
-    return order === 'date-desc' ? bTs - aTs : aTs - bTs
-  })
+// Unparseable / missing dates sort last (most distant in the requested
+// direction) rather than producing NaN comparisons, which would make the sort
+// implementation-defined.
+const DATE_DESC_SENTINEL = Number.NEGATIVE_INFINITY
+const DATE_ASC_SENTINEL = Number.POSITIVE_INFINITY
+
+/**
+ * Sort enriched games by per-product release date, falling back to the upstream
+ * order (the server's `conceptReleaseDate`-desc grid order) as a STABLE
+ * tiebreaker. Without this, equal or unparseable dates reorder
+ * nondeterministically across requests; the tiebreaker keeps the official
+ * grid order Sony already returns for ties (see the spike doc, section B).
+ */
+const sortByDate = (games: Game[], order: SortOrder): Game[] => {
+  const sentinel = order === 'date-desc' ? DATE_DESC_SENTINEL : DATE_ASC_SENTINEL
+  const tsOf = (game: Game): number => {
+    const parsed = Date.parse(game.date)
+    return Number.isNaN(parsed) ? sentinel : parsed
+  }
+
+  return games
+    .map((game, index) => ({ game, index }))
+    .sort((a, b) => {
+      const aTs = tsOf(a.game)
+      const bTs = tsOf(b.game)
+      const byDate = order === 'date-desc' ? bTs - aTs : aTs - bTs
+      return byDate !== 0 ? byDate : a.index - b.index
+    })
+    .map((entry) => entry.game)
+}
 
 const paginate = (games: Game[], offset: number, size: number): PageResult => {
   const page = games.slice(offset, offset + size)
@@ -148,9 +172,17 @@ export const getDiscountedGames = async (offset = 0, size = 60): Promise<PageRes
 export const getPlusGames = async (offset = 0, size = 60): Promise<PageResult> =>
   enrichedListing(mapConceptsToGames(await featureConcepts('plus')), 'date-desc', 'released', offset, size)
 
-const enrichGameWithDetail = async (game: Game): Promise<Game> => {
+// Function-injection seam (AGENTS.md §3.2 / §13 forbid DI containers and
+// Service classes). The optional fetcher defaults to the real boundary and is
+// overridden only by tests with an in-memory fake (AGENTS.md §9).
+type FetchProductDetail = typeof fetchProductDetail
+
+const enrichGameWithDetail = async (
+  game: Game,
+  fetchDetail: FetchProductDetail,
+): Promise<Game> => {
   try {
-    const detail = await fetchProductDetail(game.id)
+    const detail = await fetchDetail(game.id)
     return {
       ...game,
       date: detail.releaseDate ?? game.date,
@@ -164,7 +196,10 @@ const enrichGameWithDetail = async (game: Game): Promise<Game> => {
   }
 }
 
-export const getGameById = async (id: string): Promise<Game> => {
+export const getGameById = async (
+  id: string,
+  fetchDetail: FetchProductDetail = fetchProductDetail,
+): Promise<Game> => {
   const cached = cache.get<Game>(detailCacheKey(id))
   if (cached) {
     return gameSchema.parse(cached)
@@ -174,7 +209,7 @@ export const getGameById = async (id: string): Promise<Game> => {
   const game = games.find((item) => item.id === id)
 
   if (game) {
-    const enriched = await enrichGameWithDetail(game)
+    const enriched = await enrichGameWithDetail(game, fetchDetail)
     cache.set(detailCacheKey(enriched.id), enriched, DETAIL_TTL_MS)
     return gameSchema.parse(enriched)
   }
@@ -182,7 +217,7 @@ export const getGameById = async (id: string): Promise<Game> => {
   for (const feature of ['upcoming', 'discounted', 'plus'] as const) {
     const featureGame = await findGameInFeatureConcepts(feature, id)
     if (featureGame) {
-      const enriched = await enrichGameWithDetail(featureGame)
+      const enriched = await enrichGameWithDetail(featureGame, fetchDetail)
       cache.set(detailCacheKey(enriched.id), enriched, DETAIL_TTL_MS)
       return gameSchema.parse(enriched)
     }

--- a/server/src/sony/productDetailSchema.ts
+++ b/server/src/sony/productDetailSchema.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+/**
+ * Zod boundary schema for Sony's `data.productRetrieve` node
+ * (operation `metGetProductById`).
+ *
+ * Deliberately tolerant (STACK.md §7 requires zod-validated parsing of every
+ * external response, AGENTS.md §6.1 keeps decoding in the service layer): every
+ * field is optional and unknown keys pass through (Zod 4 `z.looseObject`, the
+ * non-deprecated replacement for `.passthrough()`), so a Sony shape change
+ * degrades to empty description / genres rather than throwing and failing the
+ * request. Only the fields the PDP enrichment reads are described.
+ */
+const sonyDescriptionSchema = z.looseObject({
+  type: z.string().optional(),
+  subType: z.string().nullish(),
+  value: z.string().optional(),
+})
+
+const sonyLocalizedGenreSchema = z.looseObject({
+  value: z.string().optional(),
+})
+
+export const productRetrieveSchema = z.looseObject({
+  id: z.string().optional(),
+  releaseDate: z.string().optional(),
+  publisherName: z.string().optional(),
+  descriptions: z.array(sonyDescriptionSchema).optional(),
+  combinedLocalizedGenres: z.array(sonyLocalizedGenreSchema).optional(),
+})
+
+export type ProductRetrieveNode = z.infer<typeof productRetrieveSchema>
+
+/**
+ * Parse the `productRetrieve` node defensively. Returns the validated node, or
+ * `null` when the payload is missing or malformed — callers degrade to empty
+ * values rather than surfacing a transport-level failure to the user.
+ */
+export const parseProductRetrieve = (node: unknown): ProductRetrieveNode | null => {
+  if (node === null || node === undefined) {
+    return null
+  }
+
+  const result = productRetrieveSchema.safeParse(node)
+  return result.success ? result.data : null
+}

--- a/server/src/sony/sonyClient.ts
+++ b/server/src/sony/sonyClient.ts
@@ -1,5 +1,6 @@
 import { env } from '../config/env.js'
 import { fetchWithRetry } from '../lib/http.js'
+import { parseProductRetrieve } from './productDetailSchema.js'
 import { sonyStrategies, type SonyFeature, type StrategyContext } from './queryStrategies.js'
 import type { CategoryGridProduct, CategoryGridRetrieveResponse, Concept, ProductRetrieveResponse } from './types.js'
 
@@ -87,13 +88,37 @@ export interface ProductDetailResult {
   publisherName?: string | undefined
 }
 
+/**
+ * Sony's `productRetrieve.descriptions[]` carries several typed entries. The
+ * PDP "game info" panel uses the LONG body, falling back to the SHORT tagline.
+ * COMPATIBILITY_NOTICE and LEGAL entries are never user-facing copy and are
+ * excluded.
+ */
+const descriptionByType = (
+  descriptions: ReadonlyArray<{ type?: string | undefined; value?: string | undefined }>,
+  type: 'LONG' | 'SHORT',
+): string => {
+  const match = descriptions.find((entry) => entry.type === type)
+  const value = match?.value
+  return typeof value === 'string' ? value : ''
+}
+
 export const extractProductDetail = (json: ProductRetrieveResponse): ProductDetailResult => {
-  const product = json.data?.productRetrieve
+  // Validate at the trust boundary (STACK.md §7). A malformed or missing node
+  // degrades to empty description / genres instead of throwing (AGENTS.md §5.1).
+  const product = parseProductRetrieve(json.data?.productRetrieve)
+
   const releaseDate = typeof product?.releaseDate === 'string' && product.releaseDate.length > 0
     ? product.releaseDate
     : undefined
-  const genres = product?.genres ?? []
-  const description = product?.longDescription ?? product?.description ?? ''
+
+  const descriptions = product?.descriptions ?? []
+  const description = descriptionByType(descriptions, 'LONG') || descriptionByType(descriptions, 'SHORT')
+
+  const genres = (product?.combinedLocalizedGenres ?? [])
+    .map((genre) => genre.value)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+
   const publisherName = typeof product?.publisherName === 'string' && product.publisherName.length > 0
     ? product.publisherName
     : undefined
@@ -132,4 +157,3 @@ export const fetchProductReleaseDate = async (productId: string): Promise<string
   const detail = await fetchProductDetail(productId)
   return detail.releaseDate
 }
-

--- a/server/src/sony/types.ts
+++ b/server/src/sony/types.ts
@@ -51,13 +51,22 @@ export interface CategoryGridRetrieveResponse {
     | undefined
 }
 
+export interface SonyDescription {
+  type?: string | undefined
+  subType?: string | null | undefined
+  value?: string | undefined
+}
+
+export interface SonyLocalizedGenre {
+  value?: string | undefined
+}
+
 export interface ProductDetail {
   id?: string | undefined
   releaseDate?: string | undefined
   publisherName?: string | undefined
-  genres?: string[] | undefined
-  description?: string | undefined
-  longDescription?: string | undefined
+  descriptions?: SonyDescription[] | undefined
+  combinedLocalizedGenres?: SonyLocalizedGenre[] | undefined
 }
 
 export interface ProductRetrieveResponse {


### PR DESCRIPTION
<!-- No backlog issue: this work was human-directed. Intentionally no `Closes #n` line (CLAUDE.md → Backlog, "Omit only when the task has no backlog issue"). -->

## Why

Users reported two problems: the PDP was missing its "game info" description and genres, and listings looked different from the official store. A read-only architect spike captured the live anonymous fi-FI Sony GraphQL and found the root causes.

- **PDP (the real bug):** `server/src/sony/sonyClient.ts → extractProductDetail` read response fields that do not exist on `data.productRetrieve` (`genres` / `description` / `longDescription`), so the PDP description was always `''` and genres always `[]`. The real shape is `descriptions[] = { type, subType, value }` (use `LONG`, then `SHORT`; never `COMPATIBILITY_NOTICE` / `LEGAL`) and `combinedLocalizedGenres[] = { value }`. `AGENTS.md §6.1` (decoding lives in the service layer) and `STACK.md §7` (zod-validated parsing of every external response) are at play.
- **Listing divergence (medium confidence):** the `categoryGridRetrieve` server order already IS the official browse order; the divergence is the client-side re-sort + `released` filter after per-item enrichment. The official browse head is dominated by undated FUTURE placeholders, so chasing byte-for-byte parity would violate `VISION.md → Product Shape #1` (NEW = released, newest-first). We do not chase parity.

## What

- `server/src/sony/types.ts` — `ProductDetail` now models the real `descriptions[]` (`SonyDescription`) and `combinedLocalizedGenres[]` (`SonyLocalizedGenre`); removed the non-existent `genres` / `description` / `longDescription` fields.
- `server/src/sony/productDetailSchema.ts` (new) — tolerant zod boundary schema for the `productRetrieve` node (`z.looseObject`, all fields optional). Parse failure / missing node degrades to empty values, never throws.
- `server/src/sony/sonyClient.ts` — `extractProductDetail` rewritten to the real field paths; returns the unchanged `ProductDetailResult` shape so `gamesService` wiring is untouched.
- `server/src/services/gamesService.ts` — `sortByDate` made deterministic: equal / unparseable dates fall back to the upstream `conceptReleaseDate`-desc grid order as a stable tiebreaker (no more implementation-defined `NaN` comparisons). Added a function-injection seam (optional `fetchDetail` param defaulting to the real boundary) to `getGameById` — no DI container.
- `server/src/__tests__/sonyClient.test.ts`, `server/src/__tests__/gamesService.test.ts` — tests for the new extraction (LONG/SHORT/excluded types, empty + malformed degraded paths), the enrichment via the fake boundary, the rejection-degrades path, and stable tie ordering.
- `docs/contracts/reports/graphql-store-parity-spike.md` (new) — the spike findings (capability map, field-usage matrix, listing root cause + VISION conclusion, PDP finding). Privacy-clean: operation names, public persisted-query hashes, variable shapes, field paths, ids, prose only.
- `docs/contracts/samples/pragmata-pdp-descriptions-genres.json` (new) — sanitized, synthetic `productRetrieve` fixture.
- Confirmed (no change needed): `client/src/components/GameDetailsPage.tsx` already renders `game.description` (DOMPurify-sanitized) and `game.genres` conditionally; the shared `Game` schema already has `description: string` and `genres: string[]`.

## VISION decision filter

The four questions in `VISION.md → Decision Filter` (ux-guardian: ACCEPT with two guardrails — see Notes):

1. *Does it help a Finnish PS5 owner reach relevant PlayStation Store data with fewer clicks or less noise than store.playstation.com?* — **yes**. The PDP now actually shows the game-info description and genres instead of an empty panel; NEW stays released-newest-first.
2. *Can it be implemented without user accounts, login, or any stored user preferences / per-user state?* — **yes**. Reuses the existing anonymous `metGetProductById` op; no identity, no new persistence, no per-user state.
3. *Does the result stay scoped to PS5 games in the Finnish store at EUR pricing, with both standard and PS Plus prices visible?* — **yes**. No scope change; all non-game / non-PS5 / DLC / edition / currency / theme / PS4 filtering preserved; prices untouched.
4. *Does it preserve the utilitarian surface — only essential data, no decorative chrome, no marketing-style content, no notifications, no social features?* — **yes**. Only descriptive metadata (description, genres, studio, release date). No ratings/reviews, no trailer/screenshot carousel additions, no related games.

All four are **yes**.

## AGENTS.md / STACK.md sections involved

- `AGENTS.md §3.1 / §3.2` — change lives in Infrastructure (Sony adapter) + Domain (service); function-injection test seam instead of a DI container / Service class.
- `AGENTS.md §5.1` — PDP degraded state: a missing / malformed `productRetrieve` node yields empty description / genres; the existing `getGameById` try/catch returns the un-enriched game on upstream failure.
- `AGENTS.md §6.1 / §6.2` — request construction and decoding stay in the service layer; no raw decoding in views/handlers.
- `AGENTS.md §8` / `VISION.md → Persistence and Privacy Posture` — spike doc + fixture carry no headers, cookies, tokens, or PII; persisted-query hashes are public client constants.
- `AGENTS.md §9` — pure extraction logic tested first (edge cases: LONG/SHORT/excluded types, empty, malformed); service driven by an in-memory fake.
- `AGENTS.md §14.1` — two autonomy-fallback choices documented in Notes.
- `STACK.md §3` — verified via `pnpm test-all`; never invoked raw tools.
- `STACK.md §7` — zod-validated parsing at the external boundary; `z.looseObject` used instead of the deprecated `.passthrough()` to satisfy `@typescript-eslint/no-deprecated`.

## Verification

- [x] `$VERIFY_CMD` (`pnpm test-all`: typecheck → lint → build → tests → sony validate → sony diff --ci) ran and is green, warning-free. 84 server tests pass (incl. the new ones); `sony validate` and `sony diff --ci` pass.
- [ ] `$FORMAT_CMD` is idempotent — see Notes: `pnpm format` is intentionally not run repo-wide here.
- [x] Tests added for new logic.
- [x] Fixtures added (`pragmata-pdp-descriptions-genres.json`).
- [x] Privacy declaration: no new required-reason / required-data API; no new data flow.

## States handled

PDP (`GameDetailsPage`) — unchanged client, confirmed to render:

- [x] loading / awaiting first data (`Spinner`)
- [x] success (description + genres now populate)
- [x] empty (`hasDescription` / `genres.length > 0` guards hide empty sections)
- [x] degraded (enrichment failure returns the un-enriched game; PDP renders without description/genres)
- [x] error (`Error` component on fetch failure / missing game)

## Notes for reviewer

- **§14.1 — listing parity:** we deliberately do NOT chase official-browse parity. The official browse head is dominated by undated FUTURE placeholders; surfacing them at the top of NEW would violate `VISION.md → Product Shape #1`. The only listing change is a deterministic stable tiebreaker on equal/unparseable dates (genuine correctness, smallest surface). `SONY_CATEGORY_ID` is unchanged; the N+1 enrichment is not refactored (out of scope). Full rationale in the spike doc, section B.
- **§14.1 — `$FORMAT_CMD` not run repo-wide:** the repo has no Prettier config; the committed codebase is single-quote / no-semicolon, while bare `prettier --write` defaults to double-quote / semicolon. Running `pnpm format` rewrites ~90 unrelated files (forbidden churn) and the double-quote reformat breaks the contract-bot's quote-sensitive literal check (`'x-apollo-operation-name': strategy.operationName`). My changed files match the established repo style; the binding `$VERIFY_CMD` gate (no Prettier check) is fully green. Conservative choice: keep the diff minimal and style-consistent rather than introduce a repo-wide formatting flip in this PR.
- **Manifest contract:** `metGetProductById` (`data.productRetrieve`) is intentionally NOT added to `docs/contracts/sony-graphql-manifest.json` — the contract-bot validator asserts every manifest op's `response_path` is grid-only (`data.categoryGridRetrieve.products` / `.concepts`). The PDP op lives outside the grid-only contract by design; documented in the spike doc.
- **ux-guardian guardrails honoured:** (1) listing still filters non-game / non-PS5 / DLC / edition / currency / theme / PS4 SKUs — "align with official" never means "stop filtering"; (2) PDP surfaces only descriptive metadata — no ratings/reviews, trailers/screenshot carousels, or related-games (VISION non-goals).

---

**Next step:** run `/codereview` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)