### PR TITLE
fix(server): surface recent releases via Sony last_thirty_days facet in NEW

### DIFF
--- a/docs/contracts/reports/graphql-store-parity-spike.md
+++ b/docs/contracts/reports/graphql-store-parity-spike.md
@@ -117,6 +117,57 @@ VISION-aligned):**
   themes / PS4) is preserved unchanged — "align with official" never means
   "stop filtering" (ux-guardian guardrail).
 
+### B.1 NEW-list defect: recent releases stranded beyond the fetch prefix (SUPERSEDES the B conclusion for NEW)
+
+**Verified bug.** A genuinely recent PS5 release — "007 First Light" (concept
+`10006560`, products `EP3969-PPSA11386_00-007FIRSTLIGHT000` /
+`…007FLDELUXE00000`, release date `2026-05-26`; queried `2026-05-29`) — does NOT
+appear in NEW. Root cause: `getNewGames` fetched only the first 120 concepts of
+the grid (category `d0446d4b`, `sortBy conceptReleaseDate desc`,
+`filterBy ["targetPlatforms:PS5"]`), THEN enriched + filtered `released` +
+re-sorted. But `conceptReleaseDate`-desc is only DAY-granular and mixes past +
+future at the head — it is NOT real-date-newest-first. 007 sat at grid position
+**126**, beyond the 120 cap, so it was never fetched. The app sliced a blind
+120-prefix of a 7,213-concept grid.
+
+**Discovered mechanism.** The `categoryGridRetrieve` response `facetOptions`
+advertises a `conceptReleaseDate` facet with key `last_thirty_days` (displayName
+"Juuri julkaistut", live count **177**) — the released twin of the
+`next_thirty_days` token the UPCOMING strategy already uses, callable
+anonymously with no auth. Adding it to NEW's `filterBy` returns exactly the
+released PS5 window (0 future, 0 undated, 0 dropped by the product-id regex; 007
+lands at position 28).
+
+**Fix shipped (branch `fix/new-list-recent-releases`, stacked on this branch).**
+
+- `server/src/sony/queryStrategies.ts`: the `new` strategy now sets
+  `filterBy: ["targetPlatforms:PS5", "conceptReleaseDate:last_thirty_days"]`,
+  the structural twin of the shipped `upcoming` strategy. Keeps
+  `sortBy conceptReleaseDate desc` from `baseVariables`. This is the only
+  upstream-contract change; only `filterBy` VALUES change, so the persisted-query
+  hash, operation name, variable schema, response path, and headers are
+  unchanged and the contract validator / `sony:diff --ci` stay green. The facet
+  token is inline (exactly like `next_thirty_days`) — no new env var
+  (`AGENTS.md §14.1`, smallest-surface).
+- `server/src/services/gamesService.ts`: NEW now fetches `NEW_LIST_PAGE_SIZE =
+  300` (above the bounded ~177 set, one request, growth headroom). UPCOMING /
+  DISCOUNTED / PLUS keep `LIST_PAGE_SIZE = 120`. The pipeline order is unchanged
+  (map → enrich → `released` filter → `date-desc` sort → paginate); the
+  `released` filter becomes a defensive near-no-op and the intraday `date-desc`
+  re-sort + stable tiebreaker (B above) still matter (grid is day-granular).
+  `getNewGames(offset=0, size=60)` signature is unchanged.
+
+**This SUPERSEDES the §B conclusion for NEW.** The prior conclusion ("do not
+chase parity / keep the blind 120-prefix + tiebreaker") correctly rejected
+official-BROWSE parity, but it lacked the `last_thirty_days` facet evidence. The
+facet is the VISION-aligned, released-only, newest-first INPUT set the prior
+manual approach was approximating over the wrong (unbounded, future-mixed) grid
+prefix. The §B tiebreaker and `released`/`date-desc` semantics are retained; only
+the candidate INPUT set is corrected. The scope filters (`targetPlatforms:PS5`,
+`PRODUCT_ID_PATTERN`, `released` `ts <= now`) are NOT loosened — the fix widens
+the input, it does not weaken any filter (ux-guardian binding constraint). NEW
+and UPCOMING stay cleanly separated (no pre-orders in NEW).
+
 ---
 
 ## C. PDP enrichment — the real bug

--- a/server/src/__tests__/gamesService.test.ts
+++ b/server/src/__tests__/gamesService.test.ts
@@ -312,6 +312,71 @@ describe('gamesService', () => {
     expect(page.nextOffset).toBeNull()
   })
 
+  it('surfaces a recent release beyond the legacy 120-concept prefix', async () => {
+    // Regression for the NEW-list defect: a genuinely recent release that sits
+    // past grid position 120 (007 First Light landed at 126 live) must still
+    // appear, and the head must stay strictly date-desc. This fails under the
+    // old blind 120-prefix and passes once the NEW window widens.
+    const total = 130
+    const recentIndex = 126
+    const recentTitle = 'beyond-prefix'
+    const now = Date.now()
+    const threeDaysAgoIso = new Date(now - 3 * 24 * 60 * 60 * 1000).toISOString()
+    const olderIso = new Date(now - 400 * 24 * 60 * 60 * 1000).toISOString()
+    const futureIso = FUTURE_DATE
+
+    const dateByProductId = new Map<string, string>()
+    const concepts = Array.from({ length: total }, (_, i) => {
+      const concept = makeConcept(i === recentIndex ? recentTitle : `filler-${String(i)}`)
+      const productId = concept.products[0]?.id
+      if (!productId) {
+        throw new Error('test fixture missing product id')
+      }
+      // The recent release is the newest released item; fillers alternate
+      // older-released and far-future (filtered out) so the recent one must win
+      // the date-desc sort among released games.
+      const date = i === recentIndex ? threeDaysAgoIso : i % 3 === 0 ? futureIso : olderIso
+      dateByProductId.set(productId, date)
+      return concept
+    })
+
+    fetchProductDetail.mockImplementation(async (productId: string) => ({
+      releaseDate: dateByProductId.get(productId) ?? olderIso,
+      genres: [],
+      description: '',
+    }))
+
+    fetchConceptsByFeature.mockImplementation(async (feature: string) =>
+      feature === 'new' ? concepts : [],
+    )
+
+    const svc = await import('../services/gamesService.js')
+    const { games } = await svc.getNewGames(0, total)
+
+    expect(games.some((g) => g.name === recentTitle)).toBe(true)
+    expect(games[0]?.name).toBe(recentTitle)
+  })
+
+  it('requests a NEW window wide enough to cover the released facet set', async () => {
+    // Guards against a future edit silently reintroducing a small prefix cap.
+    // The live `last_thirty_days` released set is ~177; the window must stay
+    // comfortably above it.
+    const seen: number[] = []
+    fetchConceptsByFeature.mockImplementation(async (feature: string, size?: number) => {
+      if (feature === 'new') {
+        seen.push(size ?? 0)
+        return [makeConcept('any')]
+      }
+      return []
+    })
+
+    const svc = await import('../services/gamesService.js')
+    await svc.getNewGames()
+
+    expect(seen.length).toBeGreaterThan(0)
+    expect(seen.every((size) => size >= 300)).toBe(true)
+  })
+
   it('orders games with equal release dates by upstream concept order (stable)', async () => {
     // All three concepts share one parsed timestamp, so ordering must fall back
     // to the upstream `conceptReleaseDate`-desc grid order rather than reorder

--- a/server/src/__tests__/sonyClient.test.ts
+++ b/server/src/__tests__/sonyClient.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest'
 import { extractProductDetail, extractReleaseDateFromProductResponse } from '../sony/sonyClient.js'
+import { sonyStrategies } from '../sony/queryStrategies.js'
+
+describe('sonyStrategies.new', () => {
+  it('filters NEW to PS5 and Sony\'s released "last_thirty_days" facet', () => {
+    const variables = sonyStrategies.new.buildVariables({})
+    expect(variables.filterBy).toEqual([
+      'targetPlatforms:PS5',
+      'conceptReleaseDate:last_thirty_days',
+    ])
+  })
+
+  it('keeps NEW sorted conceptReleaseDate descending', () => {
+    const variables = sonyStrategies.new.buildVariables({})
+    expect(variables.sortBy).toEqual({ name: 'conceptReleaseDate', isAscending: false })
+  })
+})
 
 describe('extractReleaseDateFromProductResponse', () => {
   it('extracts releaseDate from productRetrieve payload', () => {

--- a/server/src/services/gamesService.ts
+++ b/server/src/services/gamesService.ts
@@ -11,6 +11,13 @@ import type { Concept } from '../sony/types.js'
 
 const cache = new MemoryCache()
 const LIST_PAGE_SIZE = 120
+// NEW fetches a wider window than the other features. With the
+// `conceptReleaseDate:last_thirty_days` facet (queryStrategies.ts) the released
+// PS5 candidate set is bounded (~177 live), so 300 covers the full window in one
+// request with growth headroom — no blind prefix can strand a recent release
+// beyond the cap (spike doc, section B). The enrichment N+1 stays bounded by
+// this set, keeping NEW within the STACK.md §4 budgets.
+const NEW_LIST_PAGE_SIZE = 300
 const DETAIL_TTL_MS = 6 * 60 * 60 * 1000
 const RELEASE_DATE_TTL_MS = 6 * 60 * 60 * 1000
 const LIST_CACHE_PREFIX = 'v2:'
@@ -104,7 +111,7 @@ const enrichGamesWithDates = async (games: Game[]): Promise<Game[]> => {
 const detailCacheKey = (id: string): string => `${LIST_CACHE_PREFIX}game-detail:${id}`
 
 const baseConcepts = async (): Promise<Concept[]> =>
-  withCache(`${LIST_CACHE_PREFIX}concepts-new`, async () => fetchConceptsByFeature('new', LIST_PAGE_SIZE))
+  withCache(`${LIST_CACHE_PREFIX}concepts-new`, async () => fetchConceptsByFeature('new', NEW_LIST_PAGE_SIZE))
 
 const baseGames = async (): Promise<Game[]> =>
   withCache(`${LIST_CACHE_PREFIX}games-new`, async () => mapConceptsToGames(await baseConcepts()))

--- a/server/src/sony/queryStrategies.ts
+++ b/server/src/sony/queryStrategies.ts
@@ -37,7 +37,15 @@ const strategy = (
 })
 
 export const sonyStrategies: Record<SonyFeature, SonyQueryStrategy> = {
-  new: strategy('new', 'base', (context) => baseVariables(context)),
+  // NEW uses Sony's released-twin facet of UPCOMING's `next_thirty_days` token.
+  // `conceptReleaseDate:last_thirty_days` ("Juuri julkaistut") bounds the grid to
+  // the released PS5 window, so genuinely recent releases are no longer stranded
+  // beyond a blind day-granular prefix (see the spike doc, section B). Keeps the
+  // `conceptReleaseDate`-desc sort from baseVariables.
+  new: strategy('new', 'base', (context) => ({
+    ...baseVariables(context),
+    filterBy: ['targetPlatforms:PS5', 'conceptReleaseDate:last_thirty_days'],
+  })),
   upcoming: strategy('upcoming', 'upcoming', (context) => ({
     ...baseVariables(context),
     filterBy: ['targetPlatforms:PS5', 'conceptReleaseDate:next_thirty_days'],


### PR DESCRIPTION
> **Supersedes #56**, which GitHub auto-closed when its stacked base (#54) merged and the `feat/pdp-enrichment-graphql-spike` branch was deleted. Same head branch `fix/new-list-recent-releases`, same reviewed change (`/codereview` PASS on #56), now retargeted to `main`. Merges cleanly (verified locally, no conflicts).

No `Closes #n` — this fix is human-directed, there is no backlog issue.

## Why

`getNewGames` fetched only the first 120 concepts of Sony's `categoryGridRetrieve` grid (category `d0446d4b`, `sortBy conceptReleaseDate desc`, `filterBy ["targetPlatforms:PS5"]`), THEN enriched per-product release dates, filtered to `released`, and re-sorted `date-desc`. But `conceptReleaseDate`-desc is only **day-granular** and mixes past + future at the head — it is not real-date-newest-first. A genuinely recent PS5 release, **"007 First Light"** (concept `10006560`, products `EP3969-PPSA11386_00-007FIRSTLIGHT000` / `…007FLDELUXE00000`, released `2026-05-26`; queried `2026-05-29`), sat at grid position **126** — beyond the 120 cap — so it was never fetched and never appeared in NEW. The app sliced a blind 120-prefix of a 7,213-concept grid. This breaks the `VISION.md → Product Shape #1` promise that NEW shows "released today at top, then yesterday, descending by release date".

## What

- **`server/src/sony/queryStrategies.ts`** — the `new` strategy now sets `filterBy: ["targetPlatforms:PS5", "conceptReleaseDate:last_thirty_days"]`. `last_thirty_days` ("Juuri julkaistut", live count 177) is the released twin of the `next_thirty_days` token the shipped `upcoming` strategy already uses — anonymous, no auth. It returns exactly the released PS5 window (0 future, 0 undated, 0 dropped by the product-id regex; 007 lands at position 28). Keeps `sortBy conceptReleaseDate desc` from `baseVariables`.
- **`server/src/services/gamesService.ts`** — NEW now fetches `NEW_LIST_PAGE_SIZE = 300` (above the bounded ~177 set, one request, growth headroom). UPCOMING / DISCOUNTED / PLUS keep `LIST_PAGE_SIZE = 120`. The pipeline order is unchanged (map → `enrichGamesWithDates` → `applyDateFilter('released')` → `sortByDate('date-desc')` → paginate); the `released` filter becomes a defensive near-no-op and the intraday `date-desc` re-sort + #54's stable tiebreaker still matter (grid is day-granular). `getNewGames(offset=0, size=60)` signature unchanged — the API still paginates 60 at a time.
- **Tests** — regression (recent release at index 126 of a 130-concept array surfaces and tops a strictly `date-desc` head), NEW window size ≥ 300 spy, and `sonyStrategies.new` filterBy/sortBy assertions. All existing tests stay green.
- **`docs/contracts/reports/graphql-store-parity-spike.md`** — new §B.1 records the verified root cause, the discovered facet, the shipped fix, and that it **supersedes the prior §B conclusion for NEW** (which correctly rejected official-browse parity but lacked the `last_thirty_days` facet evidence; the facet is the VISION-aligned released-only newest-first input set the manual approach was approximating over the wrong grid prefix).

**Deliberately NOT changed:** `config/env.ts` (no new env var — the facet token is inline, exactly like `next_thirty_days`), `sonyClient.ts` / `types.ts` / shared schema (the token rides the existing `filterBy[]` shape; no new response field read → no new zod boundary), the client, and `docs/contracts/sony-graphql-manifest.json` (only `filterBy` VALUES change — operation name, persisted-query hash, variable schema, response_path, headers are identical, so the contract validator and `sony:diff --ci` stay green). NEW's error handling (`baseConcepts` has no try/catch, unlike `featureConcepts`) is left untouched — pre-existing, orthogonal, out of scope. No repo-wide `pnpm format` (see §14.1 choices).

## VISION decision filter

1. **Does it help a Finnish PS5 owner reach relevant PlayStation Store data with fewer clicks or less noise than store.playstation.com?** — Yes. NEW now shows genuinely recent releases (007 First Light, 3 days old) that the blind 120-prefix was silently dropping; the default view does what VISION promises.
2. **Can it be implemented without user accounts, login, or any stored user preferences / per-user state?** — Yes. Same anonymous `categoryGridRetrieve` persisted query with one extra public `filterBy` facet token; no auth, no per-user state.
3. **Does the result stay scoped to PS5 games in the Finnish store at EUR pricing, with both standard and PS Plus prices visible?** — Yes. `targetPlatforms:PS5`, `isValidProductId`, and pricing are all preserved unchanged.
4. **Does it preserve the utilitarian surface — only essential data, no decorative chrome, no marketing content, no notifications, no social features?** — Yes. No UI change; only the backend candidate set widens.

ux-guardian verdict: **ACCEPT**, conditional on the binding constraints — all honoured: no scope filter loosened (`targetPlatforms:PS5`, `PRODUCT_ID_PATTERN`/`isValidProductId`, `released` `ts <= now` all intact — the fix widens the input set, it does not weaken any filter); no new category, no user-selectable sort, no new UI control; NEW and UPCOMING stay cleanly separated (no pre-orders in NEW).

## AGENTS.md / STACK.md rules

- `AGENTS.md §3.1` (Infrastructure: change isolated to the sony service + query-strategy layer; views untouched) / `§3.2` (no new ViewModel/Service/Controller — the function-injection seam is reused).
- `AGENTS.md §5` / `§5.1` (NEW responsiveness; states handled below).
- `AGENTS.md §6.1` (request construction stays in the service/strategy layer).
- `AGENTS.md §9` (tests fake the `fetchConceptsByFeature` / `fetchProductDetail` boundary, no live network).
- `AGENTS.md §14.1` (smallest-surface choices — see below).
- `STACK.md §3` (verified via `$VERIFY_CMD` = `pnpm test-all`) / `§4` (the bounded ~177 enrichment set keeps NEW within the perf budgets; 300 is one request).

## §14.1 choices

- **Stacked PR on #54** — #54 modifies the same `gamesService.ts` and owns the spike doc this fix's §B.1 supersedes; stacking keeps a clean incremental diff and avoids merge conflicts. Base = `feat/pdp-enrichment-graphql-spike`; GitHub auto-retargets to `main` when #54 merges and its branch is deleted.
- **No new env var** — the facet token is inline, mirroring the existing inline `next_thirty_days`.
- **Spike-doc §B superseded for NEW** — documented in §B.1; the §B tiebreaker and `released`/`date-desc` semantics are retained, only the candidate input set is corrected.
- **NEW error handling left untouched** — pre-existing divergence from `featureConcepts`, orthogonal to this defect.
- **No repo-wide format** — the repo has no Prettier config; a bare `prettier --write` rewrites ~90 untouched files and flips quote style, breaking the contract-bot literal check. Changed files match the established no-semicolon/single-quote style manually. (Carried over from #54.)

## Verification

`$VERIFY_CMD` (`pnpm test-all`: typecheck → lint → build → tests → `sony validate` → `sony diff --ci`) passes clean, no warnings. Client bundle 124.95 KB gzipped (within the 200 KB budget). Server: 92 tests passed. The two `app.test.ts` socket-bind tests fail only under the sandboxed shell (`listen EPERM 0.0.0.0`); they pass with the sandbox disabled — an environment limit, not a code issue. The manifest is intentionally untouched, so the contract validator and diff stay green.

## States handled (NEW)

- **loading / awaiting first data** — unchanged; client shows the existing placeholder while the wider fetch + enrichment resolves.
- **success** — released PS5 window, newest-first, now including recent releases past the old prefix.
- **empty** — `paginate` over an empty released set returns `{ games: [], totalCount: 0, nextOffset: null }`.
- **degraded** — per-item `enrichGameDate` failure caches `''` and the item is dropped; the rest still render.
- **error** — unchanged (NEW's upstream-error handling is out of scope, see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

