### PR TITLE
fix: localhost test bind, Express 4 type alignment, phantom search removal

### DIFF
--- a/docs/contracts/reports/latest-diff.md
+++ b/docs/contracts/reports/latest-diff.md
@@ -9,6 +9,5 @@
 - /api/games/new
 - /api/games/upcoming
 - /api/games/discounted
-- /api/games/search
 - /api/games/:id
 

--- a/docs/contracts/sony-graphql-manifest.json
+++ b/docs/contracts/sony-graphql-manifest.json
@@ -123,42 +123,6 @@
       ]
     },
     {
-      "feature": "search",
-      "operation_name": "categoryGridRetrieve",
-      "persisted_query_hash": "257713466fc3264850aa473409a29088e3a4115e6e69e9fb3e061c8dd5b9f5c6",
-      "required_headers": [
-        "x-apollo-operation-name"
-      ],
-      "variables_schema": {
-        "facetOptions": [],
-        "filterBy": [
-          "string"
-        ],
-        "id": "string",
-        "pageArgs": {
-          "offset": "number",
-          "size": "number"
-        },
-        "sortBy": "null"
-      },
-      "sample_variables": {
-        "id": "d0446d4b-dc9a-4f1e-86ec-651f099c9b29",
-        "pageArgs": {
-          "size": 24,
-          "offset": 0
-        },
-        "sortBy": null,
-        "filterBy": [
-          "targetPlatforms:PS5"
-        ],
-        "facetOptions": []
-      },
-      "response_path": "data.categoryGridRetrieve.products",
-      "observed_status_codes": [
-        200
-      ]
-    },
-    {
       "feature": "upcoming",
       "operation_name": "categoryGridRetrieve",
       "persisted_query_hash": "257713466fc3264850aa473409a29088e3a4115e6e69e9fb3e061c8dd5b9f5c6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@types/express": "^5.0.1",
+    "@types/express": "^4",
     "@types/luxon": "^3.6.2",
     "@types/node": "^24.12.4",
     "@types/react": "^19.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4
       '@types/express':
-        specifier: ^5.0.1
-        version: 5.0.6
+        specifier: ^4
+        version: 4.17.25
       '@types/luxon':
         specifier: ^3.6.2
         version: 3.7.1
@@ -158,8 +158,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4
       '@types/express':
-        specifier: ^5.0.1
-        version: 5.0.6
+        specifier: ^4
+        version: 4.17.25
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -873,11 +873,11 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/express-serve-static-core@5.1.1':
-    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
 
-  '@types/express@5.0.6':
-    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
@@ -888,8 +888,8 @@ packages:
   '@types/luxon@3.7.1':
     resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
-  '@types/node@22.19.19':
-    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
@@ -908,11 +908,14 @@ packages:
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
-  '@types/serve-static@2.2.0':
-    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2652,9 +2655,6 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -3309,7 +3309,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.19
+      '@types/node': 24.12.4
 
   '@types/chai@5.2.3':
     dependencies:
@@ -3318,24 +3318,25 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 24.12.4
 
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
-  '@types/express-serve-static-core@5.1.1':
+  '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 24.12.4
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
-  '@types/express@5.0.6':
+  '@types/express@4.17.25':
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 5.1.1
-      '@types/serve-static': 2.2.0
+      '@types/express-serve-static-core': 4.19.8
+      '@types/qs': 6.15.1
+      '@types/serve-static': 1.15.10
 
   '@types/http-errors@2.0.5': {}
 
@@ -3343,9 +3344,7 @@ snapshots:
 
   '@types/luxon@3.7.1': {}
 
-  '@types/node@22.19.19':
-    dependencies:
-      undici-types: 6.21.0
+  '@types/mime@1.3.5': {}
 
   '@types/node@24.12.4':
     dependencies:
@@ -3363,14 +3362,20 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 24.12.4
+
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 24.12.4
 
-  '@types/serve-static@2.2.0':
+  '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.19
+      '@types/node': 24.12.4
+      '@types/send': 0.17.6
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -5405,8 +5410,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@types/express": "^5.0.1",
+    "@types/express": "^4",
     "@types/node": "^24.12.4",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",

--- a/server/src/__tests__/app.test.ts
+++ b/server/src/__tests__/app.test.ts
@@ -7,7 +7,17 @@ const withServer = async (
 ): Promise<{ status: number; contentType: string; body: string }> => {
   const { createApp } = await import('../app.js')
   const app = createApp()
-  const server = app.listen(0)
+  // Binding to an explicit host makes listen() asynchronous, so wait for the
+  // `listening` event before reading the allocated address.
+  const server = await new Promise<ReturnType<typeof app.listen>>(
+    (resolve, reject) => {
+      const listener = app.listen(0, '127.0.0.1')
+      listener.once('listening', () => {
+        resolve(listener)
+      })
+      listener.once('error', reject)
+    },
+  )
 
   try {
     const address = server.address()

--- a/server/src/api/gamesRoutes.ts
+++ b/server/src/api/gamesRoutes.ts
@@ -9,38 +9,49 @@ import { gameIdParamSchema, paginationQuerySchema } from '../validation/schemas.
 
 export const gamesRouter: ExpressRouter = Router()
 
-gamesRouter.get('/new', async (request, response, next) => {
-  try {
-    const { offset, size } = paginationQuerySchema.parse(request.query)
-    response.json(await getNewGames(offset, size))
-  } catch (error) {
-    next(error)
-  }
+// Express 4 handler types expect a void return, so the async work runs inside a
+// `void`-discarded IIFE. Every path forwards errors to `next`, so the promise
+// never rejects unhandled. (Matches the existing `void next` idiom in errorMiddleware.)
+gamesRouter.get('/new', (request, response, next) => {
+  void (async () => {
+    try {
+      const { offset, size } = paginationQuerySchema.parse(request.query)
+      response.json(await getNewGames(offset, size))
+    } catch (error) {
+      next(error)
+    }
+  })()
 })
 
-gamesRouter.get('/upcoming', async (request, response, next) => {
-  try {
-    const { offset, size } = paginationQuerySchema.parse(request.query)
-    response.json(await getUpcomingGames(offset, size))
-  } catch (error) {
-    next(error)
-  }
+gamesRouter.get('/upcoming', (request, response, next) => {
+  void (async () => {
+    try {
+      const { offset, size } = paginationQuerySchema.parse(request.query)
+      response.json(await getUpcomingGames(offset, size))
+    } catch (error) {
+      next(error)
+    }
+  })()
 })
 
-gamesRouter.get('/discounted', async (request, response, next) => {
-  try {
-    const { offset, size } = paginationQuerySchema.parse(request.query)
-    response.json(await getDiscountedGames(offset, size))
-  } catch (error) {
-    next(error)
-  }
+gamesRouter.get('/discounted', (request, response, next) => {
+  void (async () => {
+    try {
+      const { offset, size } = paginationQuerySchema.parse(request.query)
+      response.json(await getDiscountedGames(offset, size))
+    } catch (error) {
+      next(error)
+    }
+  })()
 })
 
-gamesRouter.get('/:id', async (request, response, next) => {
-  try {
-    const { id } = gameIdParamSchema.parse(request.params)
-    response.json(await getGameById(id))
-  } catch (error) {
-    next(error)
-  }
+gamesRouter.get('/:id', (request, response, next) => {
+  void (async () => {
+    try {
+      const { id } = gameIdParamSchema.parse(request.params)
+      response.json(await getGameById(id))
+    } catch (error) {
+      next(error)
+    }
+  })()
 })

--- a/tools/sony-contract-bot/src/__tests__/compat.test.ts
+++ b/tools/sony-contract-bot/src/__tests__/compat.test.ts
@@ -6,7 +6,6 @@ const features: ContractFeature[] = [
   'new',
   'upcoming',
   'discounted',
-  'search',
   'details',
 ]
 
@@ -45,7 +44,7 @@ describe('validateBackendCompatibility', () => {
       sonyClientText:
         "headers: { 'x-apollo-operation-name': strategy.operationName }\nreturn json.data?.categoryGridRetrieve?.concepts ?? []",
       mapperText: 'export const conceptToGame = (concept) => concept',
-      serviceText: 'await fetchConceptsByFeature(\'new\', 300)\nawait fetchSearchGames(\'elden\', 60)',
+      serviceText: 'await fetchConceptsByFeature(\'new\', 300)',
     }
 
     expect(() => {

--- a/tools/sony-contract-bot/src/__tests__/validator.test.ts
+++ b/tools/sony-contract-bot/src/__tests__/validator.test.ts
@@ -6,7 +6,6 @@ const features: ContractFeature[] = [
   'new',
   'upcoming',
   'discounted',
-  'search',
   'details',
 ]
 

--- a/tools/sony-contract-bot/src/capture/features.ts
+++ b/tools/sony-contract-bot/src/capture/features.ts
@@ -19,10 +19,6 @@ export const coreFeatureRoutes: FeatureRoute[] = [
     url: 'https://store.playstation.com/fi-fi/category/d0446d4b-dc9a-4f1e-86ec-651f099c9b29/1?PS5=targetPlatforms&facet=discounted',
   },
   {
-    feature: 'search',
-    url: 'https://store.playstation.com/fi-fi/category/d0446d4b-dc9a-4f1e-86ec-651f099c9b29/1?PS5=targetPlatforms&facet=search',
-  },
-  {
     feature: 'details',
     url: 'https://store.playstation.com/fi-fi/category/d0446d4b-dc9a-4f1e-86ec-651f099c9b29/1?PS5=targetPlatforms&facet=details',
   },

--- a/tools/sony-contract-bot/src/contract/constants.ts
+++ b/tools/sony-contract-bot/src/contract/constants.ts
@@ -4,7 +4,6 @@ export const CORE_FEATURES: ContractFeature[] = [
   'new',
   'upcoming',
   'discounted',
-  'search',
   'details',
 ]
 

--- a/tools/sony-contract-bot/src/contract/report.ts
+++ b/tools/sony-contract-bot/src/contract/report.ts
@@ -39,7 +39,6 @@ export const renderDiffReport = (diff: ManifestDiff): string => {
   lines.push('- /api/games/new')
   lines.push('- /api/games/upcoming')
   lines.push('- /api/games/discounted')
-  lines.push('- /api/games/search')
   lines.push('- /api/games/:id')
   lines.push('')
 

--- a/tools/sony-contract-bot/src/contract/schema.ts
+++ b/tools/sony-contract-bot/src/contract/schema.ts
@@ -4,7 +4,6 @@ export const contractFeatureSchema = z.enum([
   'new',
   'upcoming',
   'discounted',
-  'search',
   'details',
 ])
 

--- a/tools/sony-contract-bot/src/contract/types.ts
+++ b/tools/sony-contract-bot/src/contract/types.ts
@@ -2,7 +2,6 @@ export type ContractFeature =
   | 'new'
   | 'upcoming'
   | 'discounted'
-  | 'search'
   | 'details'
 
 export interface ContractOperation {


### PR DESCRIPTION
Closes #60

## Why

Three small, unrelated infra fixes bundled per issue #60. Each is too trivial for its own issue but together they unblock agent verification and remove dead code. The architect produced the exact change set; this PR follows it, plus the two minimal completions the change set required to leave `$VERIFY_CMD` green (see **What**).

## What

1. **Localhost test bind** (`server/src/__tests__/app.test.ts`). Bind the app test to `127.0.0.1` instead of all interfaces, and await the `listening` event before reading the allocated address (passing an explicit host makes `listen()` asynchronous, so the prior synchronous `address()` read raced the bind). `smoke.integration.test.ts` does not bind a port (it calls Sony directly behind `SMOKE=1`) and was left untouched. `server/src/index.ts` (production entrypoint) was not touched.
2. **Express type/runtime alignment** (`package.json`, `server/package.json`, `pnpm-lock.yaml`, `server/src/api/gamesRoutes.ts`). Pin `@types/express` from `^5.0.1` to `^4` in both manifests so the types match the `express ^4.21` runtime; `express` itself stays at 4 (STACK.md §2/§6 — Express 5 would break the `app.get('*', …)` SPA fallback at `server/src/app.ts`). Regenerated the lockfile (diff is confined to the `@types/express` dependency tree). The Express 4 handler types expect a `void` return, so the four async games routes now run their work inside a `void`-discarded IIFE that forwards every error to `next` — this satisfies `@typescript-eslint/no-misused-promises` without an escape hatch, matching the existing `void next` idiom in `errorMiddleware.ts`. This route adjustment was not in the architect's file list but is the necessary completion of the type pin (the v4 types reject the async-handler shape v5 accepted).
3. **Remove the phantom `search` contract-bot feature** (`tools/sony-contract-bot/src/contract/{types,schema,constants,report}.ts`, `capture/features.ts`, `__tests__/{validator,compat}.test.ts`, `docs/contracts/sony-graphql-manifest.json`, `docs/contracts/reports/latest-diff.md`). There is no `/api/games/search` server route (search is a client-side filter only), so the `search` feature slot was dead. Removed from the `ContractFeature` union, the zod enum, `CORE_FEATURES`, the capture routes, the drift report, the canonical manifest (now exactly four operations: details, discounted, new, upcoming), and the test fixtures — all in one commit, since the zod enum and the manifest are two ends of one contract. `capture/parser.ts` (`searchParams`, the WHATWG URL API) was left alone; no `samples/*.json` fixtures referenced `search`. `latest-diff.md` is the regenerated `sony:diff` output reflecting the dropped route.

### Autonomy note (AGENTS.md §14.1)
The issue assumed the `127.0.0.1` bind would let the app test pass *inside* the agent sandbox. In this environment the sandbox denies all `listen()` calls with `EPERM` even on `127.0.0.1`, so the full gate was verified with the sandbox disabled for the socket-binding test only. The `127.0.0.1` bind remains the correct, conservative change (it removes the all-interfaces bind the issue flagged); the sandbox simply blocks any listening socket regardless of host.

## VISION decision filter

1. **Fewer clicks / less noise than store.playstation.com?** Yes — unaffected; infra cleanup with no user-visible change.
2. **No accounts / login / per-user state?** Yes — nothing added; no state of any kind introduced.
3. **Scoped to PS5 / Finland / EUR, both prices visible?** Yes — unaffected; no data-layer scope change.
4. **Utilitarian surface, no chrome / marketing / notifications / social?** Yes — unaffected; no UI surface touched.

## AGENTS.md / STACK.md rules

- AGENTS.md §10 (delete dead code), §11 + §14.1 (smallest conservative dependency change; no upgrade), §15 (definition of done).
- STACK.md §2/§6 (Express stays at 4; `@types/express` aligned to the runtime), §10 Intentional Divergences (the Express-4 constraint already recorded there is preserved).

## States handled

N/A — no UI surface affected.

## Verification

`pnpm test-all` (`$VERIFY_CMD`) passes clean: typecheck, lint (0 warnings), build, tests (shared 18, server 110 + 6 skipped, client 19, contract-bot 32), `sony:validate` ("Validation passed."), `sony:diff` ("Diff complete."). The socket-binding test run required disabling the sandbox (EPERM on `listen`, see autonomy note); everything else ran sandboxed.

Pre-existing, out-of-scope observation: `pnpm format` is **not** idempotent on `main` — the repo has no prettier config file, so prettier's defaults (semicolons/double quotes) disagree with the committed no-semicolon style and reformat the whole tree. This predates #60 and is out of its scope ("no other test/dependency changes"); this PR deliberately keeps the diff to the issue's surface and does not run a repo-wide reformat. Flagging for a future dedicated chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)