### PR TITLE
chore: convert fixed Sony-contract config to code constants

### DIFF
--- a/server/src/__tests__/app.test.ts
+++ b/server/src/__tests__/app.test.ts
@@ -7,7 +7,6 @@ import { gamesGroupLive } from '../api/gamesHandlers.js'
 import { GamesServiceLive } from '../services/gamesService.js'
 import { SonyClient } from '../sony/sonyClient.js'
 import type { Concept } from '../sony/types.js'
-import { EnvLive } from '../config/env.js'
 
 // A fake SonyClient: NEW returns one valid product SKU; product detail returns a
 // past release date so the released gate keeps it. No network, no real env.
@@ -35,10 +34,7 @@ const FakeSony = Layer.succeed(SonyClient, {
     }),
 })
 
-const Services = GamesServiceLive.pipe(
-  Layer.provide(FakeSony),
-  Layer.provide(EnvLive),
-)
+const Services = GamesServiceLive.pipe(Layer.provide(FakeSony))
 
 const PlatformLive = Layer.mergeAll(
   HttpPlatform.layer.pipe(Layer.provide(NodeContext.layer)),

--- a/server/src/__tests__/gamesService.test.ts
+++ b/server/src/__tests__/gamesService.test.ts
@@ -1,6 +1,5 @@
 import { Effect, Exit, Layer } from 'effect'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { EnvLive } from '../config/env.js'
 import { UpstreamUnavailable } from '../errors/errors.js'
 import {
   GamesService,
@@ -37,20 +36,14 @@ const FakeSony = Layer.succeed(SonyClient, {
 const run = <A, E>(
   use: (svc: GamesServiceApi) => Effect.Effect<A, E>,
 ): Promise<A> => {
-  const Services = GamesServiceLive.pipe(
-    Layer.provide(FakeSony),
-    Layer.provide(EnvLive),
-  )
+  const Services = GamesServiceLive.pipe(Layer.provide(FakeSony))
   return Effect.runPromise(
     GamesService.pipe(Effect.flatMap(use), Effect.provide(Services)),
   )
 }
 
 const runExit = <A, E>(use: (svc: GamesServiceApi) => Effect.Effect<A, E>) => {
-  const Services = GamesServiceLive.pipe(
-    Layer.provide(FakeSony),
-    Layer.provide(EnvLive),
-  )
+  const Services = GamesServiceLive.pipe(Layer.provide(FakeSony))
   return Effect.runPromiseExit(
     GamesService.pipe(Effect.flatMap(use), Effect.provide(Services)),
   )
@@ -610,10 +603,7 @@ describe('gamesService', () => {
       fetchProductDetail: () =>
         Effect.succeed({ releaseDate: PAST_DATE, genres: [], description: '' }),
     })
-    const Services = GamesServiceLive.pipe(
-      Layer.provide(CapturingSony),
-      Layer.provide(EnvLive),
-    )
+    const Services = GamesServiceLive.pipe(Layer.provide(CapturingSony))
     await Effect.runPromise(
       GamesService.pipe(
         Effect.flatMap((s) => s.getNewGames()),
@@ -673,10 +663,7 @@ describe('getGameById detail enrichment', () => {
         Effect.sync(() => (feature === 'new' ? [makeConcept('degraded')] : [])),
       fetchProductDetail: () => Effect.fail(upstream('boom')),
     })
-    const Services = GamesServiceLive.pipe(
-      Layer.provide(FlakySony),
-      Layer.provide(EnvLive),
-    )
+    const Services = GamesServiceLive.pipe(Layer.provide(FlakySony))
 
     const game = await Effect.runPromise(
       GamesService.pipe(

--- a/server/src/__tests__/smoke.integration.test.ts
+++ b/server/src/__tests__/smoke.integration.test.ts
@@ -1,13 +1,10 @@
-import { Effect, Layer } from 'effect'
+import { Effect } from 'effect'
 import { describe, expect, it } from 'vitest'
-import { EnvLive } from '../config/env.js'
 import { conceptToGame } from '../sony/mapper.js'
 import { SonyClient, SonyClientLive } from '../sony/sonyClient.js'
 
 const SMOKE = process.env['SMOKE'] === '1'
 const describeSmoke = SMOKE ? describe : describe.skip
-
-const LiveClient = SonyClientLive.pipe(Layer.provide(EnvLive))
 
 const fetchConcepts = (
   feature: 'new' | 'upcoming' | 'discounted',
@@ -15,7 +12,7 @@ const fetchConcepts = (
 ) =>
   SonyClient.pipe(
     Effect.flatMap((client) => client.fetchConceptsByFeature(feature, size)),
-    Effect.provide(LiveClient),
+    Effect.provide(SonyClientLive),
     Effect.runPromise,
   )
 

--- a/server/src/__tests__/sonyClient.test.ts
+++ b/server/src/__tests__/sonyClient.test.ts
@@ -4,27 +4,10 @@ import {
   extractReleaseDateFromProductResponse,
 } from '../sony/sonyClient.js'
 import { buildStrategies } from '../sony/queryStrategies.js'
-import type { AppConfig } from '../config/env.js'
-
-const config: AppConfig = {
-  NODE_ENV: 'test',
-  PORT: 3000,
-  SONY_GRAPHQL_URL: 'https://web.np.playstation.com/api/graphql/v1/op',
-  SONY_CATEGORY_GRID_HASH: 'hash',
-  SONY_CATEGORY_ID: 'category',
-  SONY_DEALS_CATEGORY_ID: 'deals',
-  SONY_OPERATION_NAME: 'categoryGridRetrieve',
-  SONY_PRODUCT_OPERATION_NAME: 'metGetProductById',
-  SONY_PRODUCT_BY_ID_HASH: 'producthash',
-  SONY_LOCALE: 'fi-fi',
-  SONY_RETRY_COUNT: 1,
-  SONY_TIMEOUT_MS: 6000,
-  CACHE_TTL_MS: 30000,
-}
 
 describe('buildStrategies.new', () => {
   it('filters NEW to PS5 and Sony\'s released "last_thirty_days" facet', () => {
-    const variables = buildStrategies(config).new.buildVariables({})
+    const variables = buildStrategies().new.buildVariables({})
     expect(variables.filterBy).toEqual([
       'targetPlatforms:PS5',
       'conceptReleaseDate:last_thirty_days',
@@ -32,7 +15,7 @@ describe('buildStrategies.new', () => {
   })
 
   it('keeps NEW sorted conceptReleaseDate descending', () => {
-    const variables = buildStrategies(config).new.buildVariables({})
+    const variables = buildStrategies().new.buildVariables({})
     expect(variables.sortBy).toEqual({
       name: 'conceptReleaseDate',
       isAscending: false,

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -1,72 +1,28 @@
-import { Config, Context, Effect, Layer } from 'effect'
+import { Duration } from 'effect'
 
-// Application configuration, read from the environment via Effect `Config`
-// (replaces the previous zod-parsed `env` object). String defaults are written
-// as `Config.withDefault('literal')` so the contract bot can still text-extract
-// the canonical operation name and endpoint (tools/sony-contract-bot
-// compat/backend.ts).
+// Fixed Sony-contract configuration. These values are part of the contract with
+// Sony's public GraphQL endpoint, not deployment knobs — they were never meant
+// to vary by environment (see issue #72). They are therefore plain code
+// constants, not env-driven `Config` values. The only genuinely
+// environment-driven setting (`PORT`) is read directly from `process.env` at
+// the HTTP composition root (server.ts). The persisted-query hashes are rotated
+// by the contract bot via `pnpm sony:refresh`, which edits this same file.
 
-export interface AppConfig {
-  readonly NODE_ENV: 'development' | 'test' | 'production'
-  readonly PORT: number
-  readonly SONY_GRAPHQL_URL: string
-  readonly SONY_CATEGORY_GRID_HASH: string
-  readonly SONY_CATEGORY_ID: string
-  readonly SONY_DEALS_CATEGORY_ID: string
-  readonly SONY_OPERATION_NAME: string
-  readonly SONY_PRODUCT_OPERATION_NAME: string
-  readonly SONY_PRODUCT_BY_ID_HASH: string
-  readonly SONY_LOCALE: string
-  readonly SONY_RETRY_COUNT: number
-  readonly SONY_TIMEOUT_MS: number
-  readonly CACHE_TTL_MS: number
-}
+export const SONY_GRAPHQL_URL =
+  'https://web.np.playstation.com/api/graphql/v1/op'
+export const SONY_CATEGORY_GRID_HASH =
+  '257713466fc3264850aa473409a29088e3a4115e6e69e9fb3e061c8dd5b9f5c6'
+export const SONY_CATEGORY_ID = 'd0446d4b-dc9a-4f1e-86ec-651f099c9b29'
+export const SONY_DEALS_CATEGORY_ID = '3f772501-f6f8-49b7-abac-874a88ca4897'
+export const SONY_OPERATION_NAME = 'categoryGridRetrieve'
+export const SONY_PRODUCT_OPERATION_NAME = 'metGetProductById'
+export const SONY_PRODUCT_BY_ID_HASH =
+  'a128042177bd93dd831164103d53b73ef790d56f51dae647064cb8f9d9fc9d1a'
+export const SONY_LOCALE = 'fi-fi'
+export const SONY_RETRY_COUNT = 1
+export const SONY_TIMEOUT_MS = 6000
 
-const appConfig: Config.Config<AppConfig> = Config.all({
-  NODE_ENV: Config.literal(
-    'development',
-    'test',
-    'production',
-  )('NODE_ENV').pipe(Config.withDefault('development')),
-  PORT: Config.integer('PORT').pipe(Config.withDefault(3000)),
-  SONY_GRAPHQL_URL: Config.string('SONY_GRAPHQL_URL').pipe(
-    Config.withDefault('https://web.np.playstation.com/api/graphql/v1/op'),
-  ),
-  SONY_CATEGORY_GRID_HASH: Config.string('SONY_CATEGORY_GRID_HASH').pipe(
-    Config.withDefault(
-      '257713466fc3264850aa473409a29088e3a4115e6e69e9fb3e061c8dd5b9f5c6',
-    ),
-  ),
-  SONY_CATEGORY_ID: Config.string('SONY_CATEGORY_ID').pipe(
-    Config.withDefault('d0446d4b-dc9a-4f1e-86ec-651f099c9b29'),
-  ),
-  SONY_DEALS_CATEGORY_ID: Config.string('SONY_DEALS_CATEGORY_ID').pipe(
-    Config.withDefault('3f772501-f6f8-49b7-abac-874a88ca4897'),
-  ),
-  SONY_OPERATION_NAME: Config.string('SONY_OPERATION_NAME').pipe(
-    Config.withDefault('categoryGridRetrieve'),
-  ),
-  SONY_PRODUCT_OPERATION_NAME: Config.string(
-    'SONY_PRODUCT_OPERATION_NAME',
-  ).pipe(Config.withDefault('metGetProductById')),
-  SONY_PRODUCT_BY_ID_HASH: Config.string('SONY_PRODUCT_BY_ID_HASH').pipe(
-    Config.withDefault(
-      'a128042177bd93dd831164103d53b73ef790d56f51dae647064cb8f9d9fc9d1a',
-    ),
-  ),
-  SONY_LOCALE: Config.string('SONY_LOCALE').pipe(Config.withDefault('fi-fi')),
-  SONY_RETRY_COUNT: Config.integer('SONY_RETRY_COUNT').pipe(
-    Config.withDefault(1),
-  ),
-  SONY_TIMEOUT_MS: Config.integer('SONY_TIMEOUT_MS').pipe(
-    Config.withDefault(6000),
-  ),
-  CACHE_TTL_MS: Config.integer('CACHE_TTL_MS').pipe(Config.withDefault(30000)),
-})
-
-export class Env extends Context.Tag('Env')<Env, AppConfig>() {}
-
-export const EnvLive: Layer.Layer<Env> = Layer.effect(
-  Env,
-  Effect.orDie(appConfig),
-)
+// List cache TTL, pinned at 30000 ms exactly. Intentionally asymmetric with the
+// per-product DETAIL_TTL (Duration.hours(6)) in gamesService: list windows
+// refresh far more often than individual product metadata.
+export const CACHE_TTL = Duration.millis(30000)

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -10,7 +10,6 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { gamesApi } from '../api/gamesApi.js'
 import { gamesGroupLive } from '../api/gamesHandlers.js'
-import { EnvLive } from '../config/env.js'
 import { GamesServiceLive } from '../services/gamesService.js'
 import { SonyClientLive } from '../sony/sonyClient.js'
 
@@ -23,10 +22,7 @@ const clientBuildPath = path.resolve(dirname, '../../../client/build')
 const indexHtmlPath = path.join(clientBuildPath, 'index.html')
 
 // Service graph for the games API handlers.
-const ServicesLive = GamesServiceLive.pipe(
-  Layer.provide(SonyClientLive),
-  Layer.provide(EnvLive),
-)
+const ServicesLive = GamesServiceLive.pipe(Layer.provide(SonyClientLive))
 
 // Mount the typed REST API (prefix /api/games is declared on the group).
 const ApiRoutes = HttpLayerRouter.addHttpApi(gamesApi).pipe(

--- a/server/src/services/gamesService.ts
+++ b/server/src/services/gamesService.ts
@@ -1,6 +1,6 @@
 import { gameSchema, type Game, type PageResult } from '@psstore/shared'
 import { Cache, Context, Duration, Effect, Layer, Schema } from 'effect'
-import { Env } from '../config/env.js'
+import { CACHE_TTL } from '../config/env.js'
 import { GameNotFound, type UpstreamUnavailable } from '../errors/errors.js'
 import { SonyClient, type ProductDetailResult } from '../sony/sonyClient.js'
 import type { Concept } from '../sony/types.js'
@@ -54,235 +54,236 @@ export class GamesService extends Context.Tag('GamesService')<
   GamesServiceApi
 >() {}
 
-export const GamesServiceLive: Layer.Layer<
-  GamesService,
-  never,
-  Env | SonyClient
-> = Layer.effect(
-  GamesService,
-  Effect.gen(function* () {
-    const config = yield* Env
-    const sony = yield* SonyClient
-    const listTtl = Duration.millis(config.CACHE_TTL_MS)
+export const GamesServiceLive: Layer.Layer<GamesService, never, SonyClient> =
+  Layer.effect(
+    GamesService,
+    Effect.gen(function* () {
+      const sony = yield* SonyClient
+      const listTtl = CACHE_TTL
 
-    // One cache per keyspace + TTL (no string→unknown erasure). Each cache's
-    // lookup is the side-effecting fetch; concurrent gets share a single fetch.
+      // One cache per keyspace + TTL (no string→unknown erasure). Each cache's
+      // lookup is the side-effecting fetch; concurrent gets share a single fetch.
 
-    // Concepts per feature. NEW uses the wider window; upcoming/discounted use
-    // the standard list size. Failures propagate as UpstreamUnavailable here;
-    // the upcoming/discounted call sites degrade to an empty list.
-    const conceptsCache = yield* Cache.make<
-      'new' | 'upcoming' | 'discounted',
-      Concept[],
-      UpstreamUnavailable
-    >({
-      capacity: 16,
-      timeToLive: listTtl,
-      lookup: (feature) =>
-        sony.fetchConceptsByFeature(
-          feature,
-          feature === 'new' ? NEW_LIST_PAGE_SIZE : LIST_PAGE_SIZE,
-        ),
-    })
-
-    // Per-product detail (release date, classification, genres, description,
-    // publisher), cached 6h and shared by both the list date enrichment and the
-    // PDP enrichment so each product is fetched at most once per TTL. A failed
-    // enrichment degrades to an empty detail rather than failing the listing
-    // (matches the previous per-product try/catch).
-    const productDetailCache = yield* Cache.make<string, ProductDetailResult>({
-      capacity: 10_000,
-      timeToLive: DETAIL_TTL,
-      lookup: (productId) =>
-        sony.fetchProductDetail(productId).pipe(
-          Effect.catchAll(() =>
-            Effect.succeed<ProductDetailResult>({
-              genres: [],
-              description: '',
-            }),
+      // Concepts per feature. NEW uses the wider window; upcoming/discounted use
+      // the standard list size. Failures propagate as UpstreamUnavailable here;
+      // the upcoming/discounted call sites degrade to an empty list.
+      const conceptsCache = yield* Cache.make<
+        'new' | 'upcoming' | 'discounted',
+        Concept[],
+        UpstreamUnavailable
+      >({
+        capacity: 16,
+        timeToLive: listTtl,
+        lookup: (feature) =>
+          sony.fetchConceptsByFeature(
+            feature,
+            feature === 'new' ? NEW_LIST_PAGE_SIZE : LIST_PAGE_SIZE,
           ),
-        ),
-    })
-
-    const productMeta = (productId: string): Effect.Effect<ProductMeta> =>
-      productDetailCache.get(productId).pipe(
-        Effect.map((detail) => ({
-          date: detail.releaseDate ?? '',
-          classification: detail.storeDisplayClassification ?? null,
-        })),
-      )
-
-    const featureConcepts = (
-      feature: 'upcoming' | 'discounted',
-    ): Effect.Effect<Concept[]> =>
-      conceptsCache.get(feature).pipe(
-        Effect.catchAll((error) =>
-          Effect.logWarning(
-            'feature concept query failed; using empty fallback',
-            {
-              feature,
-              reason: error._tag,
-            },
-          ).pipe(Effect.as<Concept[]>([])),
-        ),
-      )
-
-    const enrichDate = (game: Game): Effect.Effect<Game> =>
-      productMeta(game.id).pipe(
-        Effect.map((meta) => ({ ...game, date: meta.date })),
-      )
-
-    const baseGames = (): Effect.Effect<Game[], UpstreamUnavailable> =>
-      conceptsCache
-        .get('new')
-        .pipe(Effect.map((concepts) => mapConceptsToGames(concepts)))
-
-    const enrichedListing = (
-      games: Game[],
-      order: SortOrder,
-      dateFilter: 'released' | 'none',
-      offset: number,
-      size: number,
-    ): Effect.Effect<PageResult> =>
-      Effect.forEach(games, enrichDate, { concurrency: 'unbounded' }).pipe(
-        Effect.map((enriched) => enriched.filter((game) => Boolean(game.date))),
-        Effect.map((withDates) => applyDateFilter(withDates, dateFilter)),
-        Effect.map((filtered) =>
-          paginate(sortByDate(filtered, order), offset, size),
-        ),
-      )
-
-    const getNewGames = (
-      offset = 0,
-      size = 60,
-    ): Effect.Effect<PageResult, UpstreamUnavailable> =>
-      baseGames().pipe(
-        Effect.flatMap((games) =>
-          enrichedListing(games, 'date-desc', 'released', offset, size),
-        ),
-      )
-
-    // UPCOMING surfaces ALL anonymously-available upcoming PS5 games (owner
-    // ruling 2026-05-29, option a): priced product SKUs (internal PDP cards) AND
-    // concept-only announcements (price "Unknown", linking out). It does NOT use
-    // enrichedListing: it keeps SKU-less concept cards, enriches dates ONLY for
-    // product SKUs (never calls the product boundary on a bare concept id), and
-    // applies no date filter. The +Infinity ascending sentinel + stable index
-    // tiebreaker put dated SKU cards first and undated concept cards after, in
-    // Sony grid order.
-    const getUpcomingGames = (
-      offset = 0,
-      size = 60,
-    ): Effect.Effect<PageResult, UpstreamUnavailable> =>
-      featureConcepts('upcoming').pipe(
-        Effect.map((concepts) => mapUpcomingConceptsToGames(concepts)),
-        Effect.flatMap((games) =>
-          Effect.forEach(
-            games,
-            (game) =>
-              game.idKind === 'product'
-                ? enrichDate(game)
-                : Effect.succeed(game),
-            { concurrency: 'unbounded' },
-          ),
-        ),
-        Effect.map((enriched) =>
-          paginate(sortByDate(enriched, 'date-asc'), offset, size),
-        ),
-      )
-
-    // DISCOUNTED enriches each grid concept once, reading release date AND store
-    // classification, then keeps only full-game SKUs (DLC / currency / themes /
-    // editions dropped — VISION forbids them). No released-date gate; newest
-    // first.
-    const getDiscountedGames = (
-      offset = 0,
-      size = 60,
-    ): Effect.Effect<PageResult, UpstreamUnavailable> =>
-      featureConcepts('discounted').pipe(
-        Effect.map((concepts) => mapConceptsToGames(concepts)),
-        Effect.flatMap((games) =>
-          Effect.forEach(
-            games,
-            (game) =>
-              productMeta(game.id).pipe(
-                Effect.map((meta) => ({
-                  game: { ...game, date: meta.date },
-                  meta,
-                })),
-              ),
-            { concurrency: 'unbounded' },
-          ),
-        ),
-        Effect.map((enriched) =>
-          enriched
-            .filter(
-              ({ meta }) =>
-                meta.classification !== null &&
-                DISCOUNTED_GAME_CLASSIFICATIONS.has(meta.classification),
-            )
-            .map(({ game }) => game)
-            .filter((game) => Boolean(game.date)),
-        ),
-        Effect.map((gamesOnly) =>
-          paginate(sortByDate(gamesOnly, 'date-desc'), offset, size),
-        ),
-      )
-
-    const enrichWithDetail = (game: Game): Effect.Effect<Game> =>
-      productDetailCache.get(game.id).pipe(
-        Effect.map(
-          (detail): Game => ({
-            ...game,
-            date: detail.releaseDate ?? game.date,
-            genres: detail.genres.length > 0 ? [...detail.genres] : game.genres,
-            description: detail.description || game.description,
-            studio: detail.publisherName || game.studio,
-          }),
-        ),
-      )
-
-    const findInFeature = (
-      feature: 'upcoming' | 'discounted',
-      id: string,
-    ): Effect.Effect<Game | null> =>
-      featureConcepts(feature).pipe(
-        Effect.map((concepts) =>
-          concepts.filter((concept) => conceptProductId(concept) === id),
-        ),
-        Effect.map((matching) =>
-          matching.length === 0
-            ? null
-            : (mapConceptsToGames(matching).find((game) => game.id === id) ??
-              null),
-        ),
-      )
-
-    const getGameById = (
-      id: string,
-    ): Effect.Effect<Game, GameNotFound | UpstreamUnavailable> =>
-      Effect.gen(function* () {
-        const games = yield* baseGames()
-        const base = games.find((item) => item.id === id)
-        if (base) {
-          return decodeGame(yield* enrichWithDetail(base))
-        }
-
-        for (const feature of ['upcoming', 'discounted'] as const) {
-          const featureGame = yield* findInFeature(feature, id)
-          if (featureGame) {
-            return decodeGame(yield* enrichWithDetail(featureGame))
-          }
-        }
-
-        return yield* Effect.fail(new GameNotFound({ id }))
       })
 
-    return GamesService.of({
-      getNewGames,
-      getUpcomingGames,
-      getDiscountedGames,
-      getGameById,
-    })
-  }),
-)
+      // Per-product detail (release date, classification, genres, description,
+      // publisher), cached 6h and shared by both the list date enrichment and the
+      // PDP enrichment so each product is fetched at most once per TTL. A failed
+      // enrichment degrades to an empty detail rather than failing the listing
+      // (matches the previous per-product try/catch).
+      const productDetailCache = yield* Cache.make<string, ProductDetailResult>(
+        {
+          capacity: 10_000,
+          timeToLive: DETAIL_TTL,
+          lookup: (productId) =>
+            sony.fetchProductDetail(productId).pipe(
+              Effect.catchAll(() =>
+                Effect.succeed<ProductDetailResult>({
+                  genres: [],
+                  description: '',
+                }),
+              ),
+            ),
+        },
+      )
+
+      const productMeta = (productId: string): Effect.Effect<ProductMeta> =>
+        productDetailCache.get(productId).pipe(
+          Effect.map((detail) => ({
+            date: detail.releaseDate ?? '',
+            classification: detail.storeDisplayClassification ?? null,
+          })),
+        )
+
+      const featureConcepts = (
+        feature: 'upcoming' | 'discounted',
+      ): Effect.Effect<Concept[]> =>
+        conceptsCache.get(feature).pipe(
+          Effect.catchAll((error) =>
+            Effect.logWarning(
+              'feature concept query failed; using empty fallback',
+              {
+                feature,
+                reason: error._tag,
+              },
+            ).pipe(Effect.as<Concept[]>([])),
+          ),
+        )
+
+      const enrichDate = (game: Game): Effect.Effect<Game> =>
+        productMeta(game.id).pipe(
+          Effect.map((meta) => ({ ...game, date: meta.date })),
+        )
+
+      const baseGames = (): Effect.Effect<Game[], UpstreamUnavailable> =>
+        conceptsCache
+          .get('new')
+          .pipe(Effect.map((concepts) => mapConceptsToGames(concepts)))
+
+      const enrichedListing = (
+        games: Game[],
+        order: SortOrder,
+        dateFilter: 'released' | 'none',
+        offset: number,
+        size: number,
+      ): Effect.Effect<PageResult> =>
+        Effect.forEach(games, enrichDate, { concurrency: 'unbounded' }).pipe(
+          Effect.map((enriched) =>
+            enriched.filter((game) => Boolean(game.date)),
+          ),
+          Effect.map((withDates) => applyDateFilter(withDates, dateFilter)),
+          Effect.map((filtered) =>
+            paginate(sortByDate(filtered, order), offset, size),
+          ),
+        )
+
+      const getNewGames = (
+        offset = 0,
+        size = 60,
+      ): Effect.Effect<PageResult, UpstreamUnavailable> =>
+        baseGames().pipe(
+          Effect.flatMap((games) =>
+            enrichedListing(games, 'date-desc', 'released', offset, size),
+          ),
+        )
+
+      // UPCOMING surfaces ALL anonymously-available upcoming PS5 games (owner
+      // ruling 2026-05-29, option a): priced product SKUs (internal PDP cards) AND
+      // concept-only announcements (price "Unknown", linking out). It does NOT use
+      // enrichedListing: it keeps SKU-less concept cards, enriches dates ONLY for
+      // product SKUs (never calls the product boundary on a bare concept id), and
+      // applies no date filter. The +Infinity ascending sentinel + stable index
+      // tiebreaker put dated SKU cards first and undated concept cards after, in
+      // Sony grid order.
+      const getUpcomingGames = (
+        offset = 0,
+        size = 60,
+      ): Effect.Effect<PageResult, UpstreamUnavailable> =>
+        featureConcepts('upcoming').pipe(
+          Effect.map((concepts) => mapUpcomingConceptsToGames(concepts)),
+          Effect.flatMap((games) =>
+            Effect.forEach(
+              games,
+              (game) =>
+                game.idKind === 'product'
+                  ? enrichDate(game)
+                  : Effect.succeed(game),
+              { concurrency: 'unbounded' },
+            ),
+          ),
+          Effect.map((enriched) =>
+            paginate(sortByDate(enriched, 'date-asc'), offset, size),
+          ),
+        )
+
+      // DISCOUNTED enriches each grid concept once, reading release date AND store
+      // classification, then keeps only full-game SKUs (DLC / currency / themes /
+      // editions dropped — VISION forbids them). No released-date gate; newest
+      // first.
+      const getDiscountedGames = (
+        offset = 0,
+        size = 60,
+      ): Effect.Effect<PageResult, UpstreamUnavailable> =>
+        featureConcepts('discounted').pipe(
+          Effect.map((concepts) => mapConceptsToGames(concepts)),
+          Effect.flatMap((games) =>
+            Effect.forEach(
+              games,
+              (game) =>
+                productMeta(game.id).pipe(
+                  Effect.map((meta) => ({
+                    game: { ...game, date: meta.date },
+                    meta,
+                  })),
+                ),
+              { concurrency: 'unbounded' },
+            ),
+          ),
+          Effect.map((enriched) =>
+            enriched
+              .filter(
+                ({ meta }) =>
+                  meta.classification !== null &&
+                  DISCOUNTED_GAME_CLASSIFICATIONS.has(meta.classification),
+              )
+              .map(({ game }) => game)
+              .filter((game) => Boolean(game.date)),
+          ),
+          Effect.map((gamesOnly) =>
+            paginate(sortByDate(gamesOnly, 'date-desc'), offset, size),
+          ),
+        )
+
+      const enrichWithDetail = (game: Game): Effect.Effect<Game> =>
+        productDetailCache.get(game.id).pipe(
+          Effect.map(
+            (detail): Game => ({
+              ...game,
+              date: detail.releaseDate ?? game.date,
+              genres:
+                detail.genres.length > 0 ? [...detail.genres] : game.genres,
+              description: detail.description || game.description,
+              studio: detail.publisherName || game.studio,
+            }),
+          ),
+        )
+
+      const findInFeature = (
+        feature: 'upcoming' | 'discounted',
+        id: string,
+      ): Effect.Effect<Game | null> =>
+        featureConcepts(feature).pipe(
+          Effect.map((concepts) =>
+            concepts.filter((concept) => conceptProductId(concept) === id),
+          ),
+          Effect.map((matching) =>
+            matching.length === 0
+              ? null
+              : (mapConceptsToGames(matching).find((game) => game.id === id) ??
+                null),
+          ),
+        )
+
+      const getGameById = (
+        id: string,
+      ): Effect.Effect<Game, GameNotFound | UpstreamUnavailable> =>
+        Effect.gen(function* () {
+          const games = yield* baseGames()
+          const base = games.find((item) => item.id === id)
+          if (base) {
+            return decodeGame(yield* enrichWithDetail(base))
+          }
+
+          for (const feature of ['upcoming', 'discounted'] as const) {
+            const featureGame = yield* findInFeature(feature, id)
+            if (featureGame) {
+              return decodeGame(yield* enrichWithDetail(featureGame))
+            }
+          }
+
+          return yield* Effect.fail(new GameNotFound({ id }))
+        })
+
+      return GamesService.of({
+        getNewGames,
+        getUpcomingGames,
+        getDiscountedGames,
+        getGameById,
+      })
+    }),
+  )

--- a/server/src/sony/queryStrategies.ts
+++ b/server/src/sony/queryStrategies.ts
@@ -1,4 +1,10 @@
-import type { AppConfig } from '../config/env.js'
+import {
+  SONY_CATEGORY_GRID_HASH,
+  SONY_CATEGORY_ID,
+  SONY_DEALS_CATEGORY_ID,
+  SONY_LOCALE,
+  SONY_OPERATION_NAME,
+} from '../config/env.js'
 
 export type SonyFeature = 'new' | 'upcoming' | 'discounted'
 
@@ -15,12 +21,9 @@ export interface SonyQueryStrategy {
   buildVariables: (context: StrategyContext) => Record<string, unknown>
 }
 
-const baseVariables = (
-  config: AppConfig,
-  context: StrategyContext,
-): Record<string, unknown> => ({
-  id: config.SONY_CATEGORY_ID,
-  locale: config.SONY_LOCALE,
+const baseVariables = (context: StrategyContext): Record<string, unknown> => ({
+  id: SONY_CATEGORY_ID,
+  locale: SONY_LOCALE,
   pageArgs: { size: context.size ?? 300, offset: context.offset ?? 0 },
   sortBy: { name: 'conceptReleaseDate', isAscending: false },
   filterBy: ['targetPlatforms:PS5'],
@@ -28,37 +31,34 @@ const baseVariables = (
 })
 
 const strategy = (
-  config: AppConfig,
   feature: SonyFeature,
   fallbackKey: SonyQueryStrategy['fallbackKey'],
   buildVariables: SonyQueryStrategy['buildVariables'],
 ): SonyQueryStrategy => ({
   feature,
-  operationName: config.SONY_OPERATION_NAME,
-  persistedQueryHash: config.SONY_CATEGORY_GRID_HASH,
+  operationName: SONY_OPERATION_NAME,
+  persistedQueryHash: SONY_CATEGORY_GRID_HASH,
   fallbackKey,
   buildVariables,
 })
 
-export const buildStrategies = (
-  config: AppConfig,
-): Record<SonyFeature, SonyQueryStrategy> => ({
+export const buildStrategies = (): Record<SonyFeature, SonyQueryStrategy> => ({
   // NEW uses Sony's released-twin facet of UPCOMING's `next_thirty_days` token.
   // `conceptReleaseDate:last_thirty_days` ("Juuri julkaistut") bounds the grid to
   // the released PS5 window, so genuinely recent releases are no longer stranded
   // beyond a blind day-granular prefix (see the spike doc, section B). Keeps the
   // `conceptReleaseDate`-desc sort from baseVariables.
-  new: strategy(config, 'new', 'base', (context) => ({
-    ...baseVariables(config, context),
+  new: strategy('new', 'base', (context) => ({
+    ...baseVariables(context),
     filterBy: ['targetPlatforms:PS5', 'conceptReleaseDate:last_thirty_days'],
   })),
-  upcoming: strategy(config, 'upcoming', 'upcoming', (context) => ({
-    ...baseVariables(config, context),
+  upcoming: strategy('upcoming', 'upcoming', (context) => ({
+    ...baseVariables(context),
     filterBy: ['targetPlatforms:PS5', 'conceptReleaseDate:next_thirty_days'],
   })),
-  discounted: strategy(config, 'discounted', 'discounted', (context) => ({
-    ...baseVariables(config, context),
-    id: config.SONY_DEALS_CATEGORY_ID,
+  discounted: strategy('discounted', 'discounted', (context) => ({
+    ...baseVariables(context),
+    id: SONY_DEALS_CATEGORY_ID,
     filterBy: ['targetPlatforms:PS5'],
   })),
 })

--- a/server/src/sony/sonyClient.ts
+++ b/server/src/sony/sonyClient.ts
@@ -1,6 +1,12 @@
 import { Context, Effect, Layer } from 'effect'
-import { Env } from '../config/env.js'
-import type { AppConfig } from '../config/env.js'
+import {
+  SONY_GRAPHQL_URL,
+  SONY_LOCALE,
+  SONY_PRODUCT_BY_ID_HASH,
+  SONY_PRODUCT_OPERATION_NAME,
+  SONY_RETRY_COUNT,
+  SONY_TIMEOUT_MS,
+} from '../config/env.js'
 import { UpstreamUnavailable } from '../errors/errors.js'
 import { fetchWithRetry } from '../lib/http.js'
 import { parseProductRetrieve } from './productDetailSchema.js'
@@ -115,11 +121,10 @@ export const extractProductDetail = (
 // ---- SonyClient service (the network boundary) -----------------------------
 
 const requestConceptsPromise = async (
-  config: AppConfig,
   feature: SonyFeature,
   context: StrategyContext,
 ): Promise<Concept[]> => {
-  const strategy = buildStrategies(config)[feature]
+  const strategy = buildStrategies()[feature]
   const variables = strategy.buildVariables(context)
 
   const extensions = {
@@ -133,17 +138,17 @@ const requestConceptsPromise = async (
   }).toString()
 
   const response = await fetchWithRetry(
-    `${config.SONY_GRAPHQL_URL}?${query}`,
+    `${SONY_GRAPHQL_URL}?${query}`,
     {
       method: 'GET',
       headers: {
         Accept: 'application/json',
         'x-apollo-operation-name': strategy.operationName,
-        'x-psn-store-locale-override': localeOverride(config.SONY_LOCALE),
+        'x-psn-store-locale-override': localeOverride(SONY_LOCALE),
       },
     },
-    config.SONY_TIMEOUT_MS,
-    config.SONY_RETRY_COUNT,
+    SONY_TIMEOUT_MS,
+    SONY_RETRY_COUNT,
   )
 
   const json = (await response.json()) as CategoryGridRetrieveResponse
@@ -154,32 +159,31 @@ const requestConceptsPromise = async (
 }
 
 const requestProductDetailPromise = async (
-  config: AppConfig,
   productId: string,
 ): Promise<ProductDetailResult> => {
   const query = new URLSearchParams({
-    operationName: config.SONY_PRODUCT_OPERATION_NAME,
+    operationName: SONY_PRODUCT_OPERATION_NAME,
     variables: JSON.stringify({ productId }),
     extensions: JSON.stringify({
       persistedQuery: {
         version: 1,
-        sha256Hash: config.SONY_PRODUCT_BY_ID_HASH,
+        sha256Hash: SONY_PRODUCT_BY_ID_HASH,
       },
     }),
   }).toString()
 
   const response = await fetchWithRetry(
-    `${config.SONY_GRAPHQL_URL}?${query}`,
+    `${SONY_GRAPHQL_URL}?${query}`,
     {
       method: 'GET',
       headers: {
         Accept: 'application/json',
-        'x-apollo-operation-name': config.SONY_PRODUCT_OPERATION_NAME,
-        'x-psn-store-locale-override': localeOverride(config.SONY_LOCALE),
+        'x-apollo-operation-name': SONY_PRODUCT_OPERATION_NAME,
+        'x-psn-store-locale-override': localeOverride(SONY_LOCALE),
       },
     },
-    config.SONY_TIMEOUT_MS,
-    config.SONY_RETRY_COUNT,
+    SONY_TIMEOUT_MS,
+    SONY_RETRY_COUNT,
   )
 
   const json = (await response.json()) as ProductRetrieveResponse
@@ -208,21 +212,18 @@ export class SonyClient extends Context.Tag('SonyClient')<
   SonyClientApi
 >() {}
 
-export const SonyClientLive: Layer.Layer<SonyClient, never, Env> = Layer.effect(
+export const SonyClientLive: Layer.Layer<SonyClient> = Layer.succeed(
   SonyClient,
-  Effect.gen(function* () {
-    const config = yield* Env
-    return SonyClient.of({
-      fetchConceptsByFeature: (feature, size = 300, offset = 0) =>
-        Effect.tryPromise({
-          try: () => requestConceptsPromise(config, feature, { size, offset }),
-          catch: upstream,
-        }),
-      fetchProductDetail: (productId) =>
-        Effect.tryPromise({
-          try: () => requestProductDetailPromise(config, productId),
-          catch: upstream,
-        }),
-    })
+  SonyClient.of({
+    fetchConceptsByFeature: (feature, size = 300, offset = 0) =>
+      Effect.tryPromise({
+        try: () => requestConceptsPromise(feature, { size, offset }),
+        catch: upstream,
+      }),
+    fetchProductDetail: (productId) =>
+      Effect.tryPromise({
+        try: () => requestProductDetailPromise(productId),
+        catch: upstream,
+      }),
   }),
 )

--- a/tools/sony-contract-bot/src/__tests__/compat.test.ts
+++ b/tools/sony-contract-bot/src/__tests__/compat.test.ts
@@ -38,7 +38,7 @@ describe('validateBackendCompatibility', () => {
   it('accepts compatible manifest', () => {
     const context = {
       serverEnvText:
-        "SONY_GRAPHQL_URL: Config.string('SONY_GRAPHQL_URL').pipe(Config.withDefault('https://web.np.playstation.com/api/graphql/v1/op'))\nSONY_OPERATION_NAME: Config.string('SONY_OPERATION_NAME').pipe(Config.withDefault('categoryGridRetrieve'))",
+        "export const SONY_GRAPHQL_URL =\n  'https://web.np.playstation.com/api/graphql/v1/op'\nexport const SONY_OPERATION_NAME = 'categoryGridRetrieve'",
       sonyClientText:
         "headers: { 'x-apollo-operation-name': strategy.operationName }\nreturn json.data?.categoryGridRetrieve?.concepts ?? []",
       mapperText: 'export const conceptToGame = (concept) => concept',

--- a/tools/sony-contract-bot/src/compat/backend.ts
+++ b/tools/sony-contract-bot/src/compat/backend.ts
@@ -7,16 +7,13 @@ export interface CompatibilityContext {
   serviceText: string
 }
 
-// The server env was migrated from zod (`default('x')`) to Effect Config
-// (`Config.withDefault('x')`). Anchor on the `Config.<reader>('ENV_NAME')`
-// call (the quoted env name), then read the resolved literal of the following
-// `withDefault('…')`. Anchoring on the quoted name avoids matching the env key
-// in the `AppConfig` interface declaration that precedes the config block.
-const extractDefault = (source: string, envName: string): string | null => {
-  const pattern = new RegExp(
-    `'${envName}'\\)[\\s\\S]*?withDefault\\('([^']+)'\\)`,
-    'm',
-  )
+// The fixed Sony-contract values are plain code constants (issue #72), no
+// longer env-driven `Config.withDefault('x')` values. Anchor on the exported
+// constant assignment `NAME = 'literal'` and read the quoted literal. The
+// constants are at module scope with no preceding interface declaration to
+// collide with.
+const extractDefault = (source: string, constName: string): string | null => {
+  const pattern = new RegExp(`${constName}\\s*=\\s*'([^']+)'`, 'm')
   const match = source.match(pattern)
   return match?.[1] ?? null
 }


### PR DESCRIPTION
## Why

`server/src/config/env.ts` exposed 13 config values as env-driven `Config.withDefault(...)` settings behind an Effect `Env` service + `EnvLive` Layer. Twelve of them are fixed terms of the contract with Sony's public GraphQL (endpoint, persisted-query hashes, operation names, locale, retry/timeout, list cache TTL) — they are not deployment knobs and were never meant to vary by environment (issue #72). Carrying them as env reads cost a `Layer` dependency threaded through `SonyClientLive`, `GamesServiceLive`, and four test files, and gave a false impression that they are operator-tunable. This converts them to plain code constants, leaving `PORT` as the only genuinely environment-driven setting.

Doctrine at play: `CLAUDE.md → Code conventions` (immutable bindings, delete dead code, no global mutable state) and `CLAUDE.md → Architecture` (right-size state ownership — no `Env` service for values that never change). `STACK.md → Scope boundary` is hardened: pinning `SONY_LOCALE = 'fi-fi'` as a constant removes the runtime override path for the Finland/EUR scope.

Closes #72

## What

- `server/src/config/env.ts` — removed `Config.all`, the `AppConfig` interface, the `Env` `Context.Tag`, and the `EnvLive` Layer. Exported 12 plain named `const`s, every literal preserved exactly. `CACHE_TTL` is `Duration.millis(30000)` (pinned, with a comment noting the intentional asymmetry with `DETAIL_TTL = Duration.hours(6)`). `NODE_ENV` deleted entirely — grep confirmed it is read nowhere at runtime.
- `server/src/sony/queryStrategies.ts` — dropped the `config: AppConfig` params; `buildStrategies(config)` → `buildStrategies()`; reads constants directly.
- `server/src/sony/sonyClient.ts` — dropped `Env`/`AppConfig` import, `yield* Env`, and the `config` params; reads constants directly. `SonyClientLive` is now `Layer.Layer<SonyClient>` (no `R`); since it no longer acquires anything effectfully it uses `Layer.succeed`.
- `server/src/services/gamesService.ts` — dropped `Env`; `listTtl` comes from the `CACHE_TTL` constant; `GamesServiceLive` `R` is now `SonyClient` only.
- `server/src/http/server.ts` — removed the dead `EnvLive` import and `Layer.provide(EnvLive)`. `PORT` is still read at `process.env['PORT']` at the composition root — now the only env read.
- Tests — removed every `Layer.provide(EnvLive)` from `gamesService.test.ts` (4), `app.test.ts`, and `smoke.integration.test.ts`; deleted the hand-built `AppConfig` literal in `sonyClient.test.ts` and call `buildStrategies()` with no arg.
- `tools/sony-contract-bot/src/compat/backend.ts` — rewrote `extractDefault` to match the constant form (`NAME = '…'`) instead of `Config.withDefault('…')`, same two anchors (`SONY_OPERATION_NAME`, `SONY_GRAPHQL_URL`), same null-guard and error messages; fixed the stale zod/Config comment.
- `tools/sony-contract-bot/src/__tests__/compat.test.ts` — updated the `serverEnvText` fixture to the new constant form so the test exercises the new extractor and asserts a non-null extract.

## VISION decision filter

1. Does it help a Finnish PS5 owner reach relevant PlayStation Store data with fewer clicks or less noise than `store.playstation.com`? — **yes**. No user-facing behaviour change; the backend is identical, just simpler internally.
2. Can it be implemented without user accounts, login, or any stored user preferences / per-user state? — **yes**. No persistence touched; this removes config indirection only.
3. Does the result stay scoped to PS5 games in the Finnish store at EUR pricing, with both standard and PS Plus prices visible? — **yes**. Hardened: `SONY_LOCALE = 'fi-fi'` is now a constant, removing the runtime override path.
4. Does it preserve the utilitarian surface — only essential data, no decorative chrome, no notifications, no social features? — **yes**. Internal-only change.

All four are `yes`.

## Rules involved

- `CLAUDE.md → Code conventions` — immutable bindings by default; deleted dead config; no global mutable state introduced.
- `CLAUDE.md → Architecture (right-size state ownership)` — dropped a service (`Env`) that owned values which never change.
- `STACK.md → Scope boundary` — locale/scope pinned as a constant, not an env knob.
- `STACK.md → §3 Documentation protocol (Context7)` — Effect v3 `Duration`/`Layer` usage grounded in retrieved v3 docs before editing.

## Verification

- [x] `$VERIFY_CMD` (`pnpm test-all`) ran and is green: format:check, typecheck, lint (incl. `no-any` / `no-unsafe-*` gates), build, all tests (server 55 / client 19 / bot 16 / shared 9, 6 smoke skipped), `sony:validate` ("Validation passed"), `sony:diff --ci` ("Diff complete").
- [x] `$FORMAT_CMD` (`pnpm format`) is idempotent.
- [x] Tests updated for the new shape; the contract-bot compat test now exercises the new extractor against the new fixture and asserts a non-null extract.
- [x] No new states/surfaces; no preview/fixture states to add.
- [x] Privacy declaration unchanged — no new data flow; this removes an env path.
- [x] `Closes #72` linked above.

## States handled

N/A — internal refactor, no user- or caller-facing surface or new state.

## Notes for reviewer

- **Scope cuts applied (devils-advocate):** (1) all four test files migrated — non-negotiable or verify lands red; (2) the `env.ts` → `sony.ts` rename was **cut** — the filename is kept to minimise blast radius and avoid contract-bot `paths.ts` churn (`paths.envFile` still points at `config/env.ts`); (4) `CACHE_TTL` pinned to `Duration.millis(30000)` exactly, not "tidied" to seconds/minutes.
- **#62 sequencing:** the two persisted-query hashes stay in `server/src/config/env.ts` as constants, so issue #62's "Files to change: config/env.ts" remains valid — it will edit this same file when it lands. Hardcoding does not make hash rotation harder; `pnpm sony:refresh` is the rotation path either way.
- **Autonomy-fallback note:** `SonyClientLive` switched from `Layer.effect` to `Layer.succeed` because, with `Env` gone, it no longer performs any effectful acquisition — the service value is constructed synchronously.
